### PR TITLE
[#135948443] Upgrade Node and NPM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "find-business-days-in-range":"1.0.2"
   },
   "engines": {
-      "node": "v6.7.0",
-      "npm": "3.10.3"
+      "node": ">=v6.7.0",
+      "npm": ">=3.10.3"
     }
 }


### PR DESCRIPTION
## What

[Upgrade CF to at least v248](https://www.pivotaltracker.com/n/projects/1275640/stories/135948443)

We are upgrading our Cloud Foundry from v245 to v250, which means
the nodejs-buildpack will now be version 1.5.24, which does not support
Node v6.7.0. We configure it with a semantic version, which means the buildpack
will pick the highest version it supports. We do the same for the npm version,
otherwise the pinned npm version will eventually become out of date.

## How to review

**IMPORTANT:** do not merge until the upgrade of [cf-release to v250](https://www.pivotaltracker.com/n/projects/1275640/stories/135948443) has been completed.

To review you can trust me, or you can:
* deploy paas-cf using the test branch [`test-nodejs-upgrade`](https://github.com/alphagov/paas-cf/compare/test-nodejs-upgrade).
* push the rubbernecker app using the `master` branch, it should fail to stage because the version of Node is no longer supported.
* push from this branch and check the app restages successfully and still works.

**NOTE:** once you are done please delete the branch `test-nodejs-upgrade` on paas-cf, because I will forget.

## Who

Anyone but me