### PR TITLE
Introduce set of options for card display

### DIFF
--- a/public/css/rubbernecker.css
+++ b/public/css/rubbernecker.css
@@ -88,3 +88,41 @@
   float: right;
   font-size: 0.8em;
 }
+div.options {
+  background-color: #fff;
+  border-bottom: 1px solid #ddd;
+  height: 3em;
+  margin-top: -3em;
+  padding: .5em;
+  position: relative;
+  text-align: center;
+  z-index: 1;
+
+  -webkit-transition: all .3s ease;
+  -moz-transition: all .3s ease;
+  -ms-transition: all .3s ease;
+  -o-transition: all .3s ease;
+  transition: all .3s ease;
+}
+
+div.options.active {
+  margin-top: 0;
+}
+
+div.options a.handler {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-top: 1px solid #fff;
+  color: #666;
+  cursor: pointer;
+  display: block;
+  height: 2em;
+  line-height: 1.8em;
+  margin-top: -1px;
+  position: absolute;
+  right: 3em;
+  text-align: center;
+  text-decoration: none;
+  top: 3em;
+  width: 2em;
+}

--- a/public/css/rubbernecker.css
+++ b/public/css/rubbernecker.css
@@ -126,3 +126,11 @@ div.options a.handler {
   top: 3em;
   width: 2em;
 }
+
+div.options label {
+  margin-right: 2em;
+}
+
+div.options label:last-of-type {
+  margin-right: 0;
+}

--- a/public/js/rubbernecker.js
+++ b/public/js/rubbernecker.js
@@ -1,0 +1,80 @@
+var App = {
+    gracefulIn: function ($elements) {
+        $elements.each(function () {
+            var $element = $(this);
+
+            if (!$element.is(':hidden')) {
+                return;
+            }
+
+            $element.css('opacity', 0);
+            $element.slideDown();
+
+            setTimeout(function () {
+                $element.animate({
+                    opacity: 1
+                });
+            }, 500);
+        });
+    },
+
+    gracefulOut: function ($elements) {
+        $elements.each(function () {
+            var $element = $(this);
+
+            if ($element.is(':hidden')) {
+                return;
+            }
+
+            $element.css('opacity', 1);
+            $element.animate({
+                opacity: 0
+            });
+
+            setTimeout(function () {
+                $element.slideUp();
+            }, 500);
+        });
+    },
+
+    toggleMenu: function (e) {
+        e.preventDefault();
+
+        $('div.options').toggleClass('active');
+
+        return false;
+    },
+
+    toggleTeam: function (e) {
+        e.preventDefault();
+
+        var $switches = $('.team-switch a'),
+            target = $(this).attr('data-target'),
+            toHide = $(this).attr('data-hide');
+
+        if ($(this).hasClass('active')) {
+            return;
+        }
+
+        // Toggle active class.
+        $switches.filter('.active').removeClass('active');
+        $(this).addClass('active');
+
+        // Show all the stories.
+        App.gracefulIn($(target));
+
+        // Hide other elements if possible.
+        if (toHide) {
+            App.gracefulOut($(target).filter(toHide));
+        }
+
+        return false;
+    }
+};
+
+$(document)
+    .ready(function () {
+        $('body')
+            .on('click', '.team-switch a', App.toggleTeam)
+            .on('click', 'div.options .handler', App.toggleMenu);
+    });

--- a/public/js/rubbernecker.js
+++ b/public/js/rubbernecker.js
@@ -45,10 +45,10 @@ var App = {
         return false;
     },
 
-    toggleTeam: function (e) {
+    toggleCards: function (e) {
         e.preventDefault();
 
-        var $switches = $('.team-switch a'),
+        var $switches = $(this).parent().find('a[data-switch]'),
             target = $(this).attr('data-target'),
             toHide = $(this).attr('data-hide');
 
@@ -75,6 +75,6 @@ var App = {
 $(document)
     .ready(function () {
         $('body')
-            .on('click', '.team-switch a', App.toggleTeam)
+            .on('click', '.team-switch a', App.toggleCards)
             .on('click', 'div.options .handler', App.toggleMenu);
     });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -29,11 +29,22 @@
 </head>
 <body>
 <div class="options clearfix">
-    <div class="btn-group team-switch" role="group">
-        <a href="#" class="btn btn-sm btn-default" data-target=".story" data-hide=".team-B">Team A</a>
-        <a href="#" class="btn btn-sm btn-default active" data-target=".story">Neutral</a>
-        <a href="#" class="btn btn-sm btn-default" data-target=".story" data-hide=".team-A">Team B</a>
-    </div>
+    <label>
+        Team:
+        <div class="btn-group team-switch" role="group">
+            <a href="#" class="btn btn-sm btn-default" data-switch data-target=".story[class*='team-']" data-hide=".team-B">A</a>
+            <a href="#" class="btn btn-sm btn-default active" data-switch data-target=".story[class*='team-']">Neutral</a>
+            <a href="#" class="btn btn-sm btn-default" data-switch data-target=".story[class*='team-']" data-hide=".team-A">B</a>
+        </div>
+    </label>
+
+    <label>
+        Neutral:
+        <div class="btn-group team-switch" role="group">
+            <a href="#" class="btn btn-sm btn-default active" data-switch data-target=".story.neutral">Show</a>
+            <a href="#" class="btn btn-sm btn-default" data-switch data-target=".story.neutral" data-hide=".neutral">Hide</a>
+        </div>
+    </label>
 
     <a href="#" class="glyphicon glyphicon-cog handler"></a>
 </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -28,6 +28,16 @@
 
 </head>
 <body>
+<div class="options clearfix">
+    <div class="btn-group team-switch" role="group">
+        <a href="#" class="btn btn-sm btn-default" data-target=".story" data-hide=".team-B">Team A</a>
+        <a href="#" class="btn btn-sm btn-default active" data-target=".story">Neutral</a>
+        <a href="#" class="btn btn-sm btn-default" data-target=".story" data-hide=".team-A">Team B</a>
+    </div>
+
+    <a href="#" class="glyphicon glyphicon-cog handler"></a>
+</div>
+
 <div class="container-fluid" role="main">
     <div class="row">
         <% colclass = rejectedStory.length > 0 ? "col-md-3" : "col-md-4" %>
@@ -108,5 +118,6 @@
 <!-- I am terribly sorry for this... Really, really sorry... - Rafal -->
 <script src="js/jquery.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
+<script src="js/rubbernecker.js"></script>
 </body>
 </html>

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -1,4 +1,4 @@
-<div class="story">
+<div class="story <%= story.team ? 'team-' + story.team : '' %>">
     <div class="panel panel-<%= status %>">
         <div class="panel-heading">
             <span class="days">

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -37,9 +37,9 @@
                         More info
                     </a>
                 </div>
-                <div class="col-md-6" style="text-align:right">
-                    <% if (story.team ) { %>
-                    Team: <strong><%= story.team %></strong>
+                <div class="col-md-6 text-right">
+                    <% if (story.team) { %>
+                        Team: <strong><%= story.team %></strong>
                     <% } %>
                 </div>
             </div>

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -1,4 +1,4 @@
-<div class="story <%= story.team ? 'team-' + story.team : '' %>">
+<div class="story <%= story.team ? 'team-' + story.team : 'neutral' %>">
     <div class="panel panel-<%= status %>">
         <div class="panel-heading">
             <span class="days">


### PR DESCRIPTION
## What

It may be useful, if we provide an ability to filter the page, to display team specific cards only.

For instance, pressing `Team A` will hide cards assigned to `Team B`. There is also ability to Show/Hide neutral stories.

Although, I am sorry... This functionality brings in more JavaScript, which initially was not meant to be included in this project...

## How to review

Run the app locally and play around with the toggles.

**Pro tip:** There is a cog icon, in the top right corner. If you click on it, the options bar will drop.

Please, see my notes in the commend below.

## Who can review

Preferably, @Jonty 