### PR TITLE
Implement auto refresh

### DIFF
--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -1,7 +1,8 @@
 var request = require('request');
 var async = require('async');
 var personFetcher = require('./personFetcher');
-var findBusinessDaysInRange = require('find-business-days-in-range').calc
+var findBusinessDaysInRange = require('find-business-days-in-range').calc;
+var crypto = require('crypto')
 
 module.exports = storyFetcher;
 
@@ -58,6 +59,7 @@ internals.getStoryViewModel = function(storyDetail, membershipInfo, transitions)
             isBlocked: internals.isBlocked(story),
             hasComments: internals.hasComments(story),
             team: internals.getTeam(story),
+            status: story.current_state,
         }
     });
 
@@ -125,7 +127,62 @@ internals.calculateDaysInProgress = function(storyId, storyState, transitions) {
     return diffDays;
 }
 
-storyFetcher.getStorySummary = function(res) {
+function tokenise(play, finished, delivered, rejected) {
+    var collection = [];
+
+    if (play.length > 0) {
+        collection.push('(' + stringifyStories(play) + ')');
+    }
+    if (finished.length > 0) {
+        collection.push('(' + stringifyStories(finished) + ')');
+    }
+    if (delivered.length > 0) {
+        collection.push('(' + stringifyStories(delivered) + ')');
+    }
+    if (rejected.length > 0) {
+        collection.push('(' + stringifyStories(rejected) + ')');
+    }
+
+    return crypto.createHmac('sha512', collection.join('.')).digest('hex');
+
+    //////////
+
+    function stringifyStories(stories) {
+        var collection = [];
+
+        for (var i = 0; i < stories.length; i++) {
+            var story = stories[i];
+            var coll = [];
+            coll.push(story.id);
+            coll.push(story.team != undefined ? story.team : 'neutral');
+            coll.push(story.status);
+            coll.push(story.signOffBy);
+            coll.push(story.workers != undefined ? '[' + story.workers.join(':') + ']' : 'null');
+            coll.push('[' + getLabels(story) + ']');
+
+            collection.push(coll.join(':'));
+        }
+
+        return collection.join(';');
+    }
+
+    function getLabels(story) {
+        if (story.labels === undefined) {
+            return 'empty';
+        }
+
+        var collection = [];
+
+        for (var i = 0; i < story.labels.length; i++) {
+            var label = story.labels[i];
+            collection.push(label.name);
+        }
+
+        return collection.join(':');
+    }
+}
+
+storyFetcher.getStorySummary = function(req, res) {
     async.parallel([
             function(callback) {
                 internals.getStoriesByStatus(res, callback, "started");
@@ -155,6 +212,8 @@ storyFetcher.getStorySummary = function(res) {
                     reason: "(╯°□°）╯︵ ┻━┻"
                 });
             } else {
+                var state = req.get('x-rubbernecker-state');
+
                 var startedStories = internals.getStoryViewModel(results[0], results[1], results[5]);
                 var finishedStories = internals.getStoryViewModel(results[2], results[1], results[5]);
                 var deliveredStories = internals.getStoryViewModel(results[3], results[1], results[5]);
@@ -163,6 +222,16 @@ storyFetcher.getStorySummary = function(res) {
                 var approveSlotsLimit = res.app.get('signOffSlotsLimit');
                 var reviewSlotsFull = reviewSlotsLimit < finishedStories.length;
                 var approveSlotsFull = approveSlotsLimit < deliveredStories.length;
+                var currentState = tokenise(startedStories, finishedStories, deliveredStories, rejectedStories);
+
+                if (state != undefined) {
+                    res.setHeader('Content-Type', 'application/json');
+                    res.send(JSON.stringify({
+                        state: state === currentState ? 'clean' : 'dirty'
+                    }));
+
+                    return;
+                }
 
                 res.render('index', {
                     projectId: res.app.get('pivotalProjectId'),
@@ -173,7 +242,8 @@ storyFetcher.getStorySummary = function(res) {
                     reviewSlotsLimit: reviewSlotsLimit,
                     approveSlotsLimit: approveSlotsLimit,
                     reviewSlotsFull: reviewSlotsFull,
-                    approveSlotsFull: approveSlotsFull
+                    approveSlotsFull: approveSlotsFull,
+                    currentState: currentState
                 });
             }
         });

--- a/public/css/rubbernecker.css
+++ b/public/css/rubbernecker.css
@@ -88,6 +88,28 @@
   float: right;
   font-size: 0.8em;
 }
+
+div.update {
+  left: 0;
+  padding: 1em;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+}
+
+div.update p {
+  margin: 0;
+}
+
+div.update a {
+  color: #000000;
+  display: inline-block;
+  font-weight: bold;
+  margin-left: .5em;
+  text-decoration: none;
+}
+
 div.options {
   background-color: #fff;
   border-bottom: 1px solid #ddd;

--- a/public/js/rubbernecker.js
+++ b/public/js/rubbernecker.js
@@ -1,4 +1,58 @@
 var App = {
+    config: {
+        updateCheck: null,
+        updatePending: null,
+        countdowns: []
+    },
+
+    checkForUpdates: function () {
+        if (App.config.updatePending !== null) {
+            return;
+        }
+
+        $.ajax({
+            url: "/",
+            type: "GET",
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader('x-rubbernecker-state', currentState);
+            },
+            success: function (data, textStatus, xhr) {
+                if (data.state === 'dirty') {
+                    $('.update').slideDown();
+                    App.config.updatePending = setTimeout(App.refresh, 30 * 1000); // Refresh page in about 30 seconds.
+                    App.setupCountdown('state', 30, '.update p span');
+                }
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                console.error('Failed to obtain the update response.');
+                console.debug(jqXHR, textStatus, errorThrown);
+            }
+        });
+    },
+
+    disableUpdates: function () {
+        if (App.config.updateCheck !== null) {
+            clearInterval(App.config.updateCheck);
+            App.config.updateCheck = null;
+        }
+
+        if (App.config.updatePending !== null) {
+            clearTimeout(App.config.updatePending);
+            App.config.updatePending = null;
+        }
+
+        $('.board-updates [data-switch="on"]').removeClass('active');
+        $('.board-updates [data-switch="off"]').addClass('active');
+
+        $('.update').slideUp();
+    },
+
+    enableUpdates: function (seconds) {
+        if (App.config.updateCheck === null) {
+            App.config.updateCheck = setInterval(App.checkForUpdates, seconds * 1000);
+        }
+    },
+
     gracefulIn: function ($elements) {
         $elements.each(function () {
             var $element = $(this);
@@ -37,6 +91,26 @@ var App = {
         });
     },
 
+    refresh: function () {
+        location.reload();
+    },
+
+    setupCountdown: function (name, seconds, element) {
+        $(element).attr('data-seconds', seconds).text(seconds);
+
+        clearInterval(App.config.countdowns[name]);
+
+        App.config.countdowns[name] = setInterval(function () {
+            var left = $(element).attr('data-seconds') - 1;
+
+            if (left < 0) {
+                return;
+            }
+
+            $(element).attr('data-seconds', left).text(left);
+        }, 1000);
+    },
+
     toggleMenu: function (e) {
         e.preventDefault();
 
@@ -46,11 +120,24 @@ var App = {
     },
 
     toggleCards: function (e) {
+        App.toggleSwitch(e);
+
+        var target = $(this).attr('data-target'),
+            toHide = $(this).attr('data-hide');
+
+        // Show all the stories.
+        App.gracefulIn($(target));
+
+        // Hide other elements if possible.
+        if (toHide) {
+            App.gracefulOut($(target).filter(toHide));
+        }
+    },
+
+    toggleSwitch: function (e) {
         e.preventDefault();
 
-        var $switches = $(this).parent().find('a[data-switch]'),
-            target = $(this).attr('data-target'),
-            toHide = $(this).attr('data-hide');
+        var $switches = $(this).parent().find('a[data-switch]');
 
         if ($(this).hasClass('active')) {
             return;
@@ -60,14 +147,6 @@ var App = {
         $switches.filter('.active').removeClass('active');
         $(this).addClass('active');
 
-        // Show all the stories.
-        App.gracefulIn($(target));
-
-        // Hide other elements if possible.
-        if (toHide) {
-            App.gracefulOut($(target).filter(toHide));
-        }
-
         return false;
     }
 };
@@ -75,6 +154,18 @@ var App = {
 $(document)
     .ready(function () {
         $('body')
+            .on('click', '[data-switch]', App.toggleSwitch)
             .on('click', '.team-switch a', App.toggleCards)
-            .on('click', 'div.options .handler', App.toggleMenu);
+            .on('click', 'div.options .handler', App.toggleMenu)
+            .on('click', '.update [data-trigger="cancel"], .board-updates [data-switch="off"]', App.disableUpdates)
+            .on('click', '.board-updates [data-switch="on"]', setupUpdates)
+            .on('click', '.update [data-trigger="refresh"]', App.refresh);
+
+        setupUpdates();
+
+        //////////
+
+        function setupUpdates() {
+            App.enableUpdates(30); // Enable updates every 30 seconds.
+        }
     });

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,7 +4,7 @@ var router = express.Router();
 var storyFetcher = require('../lib/storyFetcher');
 
 router.get('/', function(req, res, next) {
-    storyFetcher.getStorySummary(res);
+    storyFetcher.getStorySummary(req, res);
 });
 
 module.exports = router;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -28,6 +28,15 @@
 
 </head>
 <body>
+
+<div class="update bg-danger" style="display: none;">
+    <p>
+        Your board may be slightly out of date. The page will be refreshed, in <span>30</span> seconds.
+        <a href="#" data-trigger="refresh">Refresh</a>
+        <a href="#" data-trigger="cancel">Cancel</a>
+    </p>
+</div>
+
 <div class="options clearfix">
     <label>
         Team:
@@ -43,6 +52,14 @@
         <div class="btn-group team-switch" role="group">
             <a href="#" class="btn btn-sm btn-default active" data-switch data-target=".story.neutral">Show</a>
             <a href="#" class="btn btn-sm btn-default" data-switch data-target=".story.neutral" data-hide=".neutral">Hide</a>
+        </div>
+    </label>
+
+    <label>
+        Updates:
+        <div class="btn-group board-updates" role="group">
+            <a href="#" class="btn btn-sm btn-default active" data-switch="on">On</a>
+            <a href="#" class="btn btn-sm btn-default" data-switch="off">Off</a>
         </div>
     </label>
 
@@ -130,5 +147,8 @@
 <script src="js/jquery.min.js"></script>
 <script src="js/bootstrap.min.js"></script>
 <script src="js/rubbernecker.js"></script>
+<script>
+    var currentState = '<%= currentState %>';
+</script>
 </body>
 </html>


### PR DESCRIPTION
## What

We'd like to avoid the situation, where somebody's board will be out of date.

Instead of, rewriting the rubbernecker to use websockets or ajax functionality, we could implement a little token checkup.

Here, we combine the most important information about the current board state and generate a SHA512 as a token, to be returned to the client.

For each story, in each state (doing, reviewing, approving and rejected)

- story: `id:team:status:signOffBy:[story:workers]:[story:labels]`
- state: `story;another_story;and_one_more`
- token: `(doing).(reviewing).(approving).(rejected)`
- return `sha512(token)`

It also sketched out, the possibility to check on the token, by comparing the one given by the client, with current on hand. It should return a json content, claiming that the token is `clean` or `dirty`.

If the change is detected, we should get a little notice, mentioning that, with a countdown giving us chance to cancel or manually refresh the page.

Option, to control auto-update has been added into option bar.

## How to review

- Fire up locally
- For convenience, you might want to change `public/js/rubbernecker.js` line `168` from 30s to 10s
- Open up rubbernecker in the browser
- Change one of the above details in a story currently on board (owner for example)
- Wait 30s or 10s and experience the notification
- Play around with this to see if UFOs haven't interfere with UX

## Who can review

Anyone but @paroxp. 