### PR TITLE
Cover the recent changes on pivotal with regards of team becoming leads

### DIFF
--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -11,16 +11,16 @@ function storyFetcher() {};
 var internals = {};
 const TRANSITION_ERROR_CODE = -99;
 
-internals.getTeam = function(story) {
-    var team;
+internals.getLead = function(story) {
+    var lead;
     story.labels.forEach(function(label) {
-        var re = new RegExp('team ([a-z])', 'gi');
+        var re = new RegExp('tech lead: ([a-z]+)', 'gi');
         var matches = re.exec(label.name);
         if(matches) {
-            team = matches[1].toUpperCase();
+            lead = matches[1].charAt(0).toUpperCase() + matches[1].slice(1).toLowerCase();
         }
     });
-    return team;
+    return lead;
 }
 
 internals.isBlocked = function(story) {
@@ -58,7 +58,7 @@ internals.getStoryViewModel = function(storyDetail, membershipInfo, transitions)
             daysInProgress: daysInProgress,
             isBlocked: internals.isBlocked(story),
             hasComments: internals.hasComments(story),
-            team: internals.getTeam(story),
+            lead: internals.getLead(story),
             status: story.current_state,
         }
     });

--- a/public/js/rubbernecker.js
+++ b/public/js/rubbernecker.js
@@ -88,44 +88,6 @@ var App = {
         }
     },
 
-    gracefulIn: function ($elements) {
-        $elements.each(function () {
-            var $element = $(this);
-
-            if (!$element.is(':hidden')) {
-                return;
-            }
-
-            $element.css('opacity', 0);
-            $element.slideDown();
-
-            setTimeout(function () {
-                $element.animate({
-                    opacity: 1
-                });
-            }, 500);
-        });
-    },
-
-    gracefulOut: function ($elements) {
-        $elements.each(function () {
-            var $element = $(this);
-
-            if ($element.is(':hidden')) {
-                return;
-            }
-
-            $element.css('opacity', 1);
-            $element.animate({
-                opacity: 0
-            });
-
-            setTimeout(function () {
-                $element.slideUp();
-            }, 500);
-        });
-    },
-
     readHash: function () {
         var urlHash = window.location.hash.slice(1),
             hash = urlHash.split('&'),
@@ -168,19 +130,6 @@ var App = {
         return false;
     },
 
-    toggleCards: function (e) {
-        var target = $(this).attr('data-target'),
-            toHide = $(this).attr('data-hide');
-
-        // Show all the stories.
-        App.gracefulIn($(target));
-
-        // Hide other elements if possible.
-        if (toHide) {
-            App.gracefulOut($(target).filter(toHide));
-        }
-    },
-
     toggleSwitch: function (e) {
         e.preventDefault();
 
@@ -211,7 +160,6 @@ $(document)
         App.readHash();
 
         $('body')
-            .on('click', '[data-switch="team"], [data-switch="neutral"]', App.toggleCards)
             .on('click', 'div.options .handler', App.toggleMenu)
             .on('click', '.update [data-trigger="cancel"], [data-switch="updates"][data-value="off"]', App.disableUpdates)
             .on('click', '[data-switch="updates"][data-value="on"]', setupUpdates)

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -39,23 +39,6 @@
 
 <div class="options clearfix">
     <label>
-        Team:
-        <div class="btn-group team-switch" role="group">
-            <a href="#" class="btn btn-sm btn-default" data-switch="team" data-value="a" data-target=".story[class*='team-']" data-hide=".team-B">A</a>
-            <a href="#" class="btn btn-sm btn-default active" data-switch="team" data-value="neutral" data-target=".story[class*='team-']">Neutral</a>
-            <a href="#" class="btn btn-sm btn-default" data-switch="team" data-value="b" data-target=".story[class*='team-']" data-hide=".team-A">B</a>
-        </div>
-    </label>
-
-    <label>
-        Neutral:
-        <div class="btn-group neutral-switch" role="group">
-            <a href="#" class="btn btn-sm btn-default active" data-switch="neutral" data-value="show" data-target=".story.neutral">Show</a>
-            <a href="#" class="btn btn-sm btn-default" data-switch="neutral" data-value="hide" data-target=".story.neutral" data-hide=".neutral">Hide</a>
-        </div>
-    </label>
-
-    <label>
         Updates:
         <div class="btn-group updates-switch" role="group">
             <a href="#" class="btn btn-sm btn-default active" data-switch="updates" data-value="on">On</a>

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -38,8 +38,8 @@
                     </a>
                 </div>
                 <div class="col-md-6 text-right">
-                    <% if (story.team) { %>
-                        Team: <strong><%= story.team %></strong>
+                    <% if (story.lead) { %>
+                        Lead: <strong><%= story.lead %></strong>
                     <% } %>
                 </div>
             </div>

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -1,4 +1,4 @@
-<div class="story <%= story.team ? 'team-' + story.team : 'neutral' %>">
+<div class="story <%= story.lead ? 'lead-' + story.lead : 'neutral' %>">
     <div class="panel panel-<%= status %>">
         <div class="panel-heading">
             <span class="days">


### PR DESCRIPTION
## What

We've changed the approach to the team split we've had thus far. 
We're going to remain as a one team and have two leads be responsible for different set of stories.

This is now irrelevant. We're now removing the pieces, which weren't required at this point, to save some resource load. This could be reverted back from the history instead.

## How to review

Aside of code sanity, check if the lead is displayed on the board. Also have a wonder to options dropdown, to establish if the filters are no longer required and indeed removed.

## Who can review

Anyone but @paroxp