### PR TITLE
Descriptions for "blocked" and "comments" labels

### DIFF
--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -81,7 +81,7 @@
 
                     <div class="col-sm-10 description">
                         Blocked!<br/>
-                        Does any body work around here?
+                        See story comments for more details
                     </div>
                 </div>
             <% } %>
@@ -94,7 +94,7 @@
 
                     <div class="col-sm-10 description">
                         Has comments to resolve<br/>
-                        Or maybe I just haven't check for a while...
+                        See story or pull request for more details
                     </div>
                 </div>
             <% } %>


### PR DESCRIPTION
## What

I was originally going to remove the "haven't checked" text because the app
now auto-refreshes in b252a65. But then I realised that we can also provide
more information to people about why the labels have been applied. It also
hints that we should always leave a comment about why a story has been given
a certain label.

## How to review

A code review is probably sufficient, since it's replacing existing text.

## Who can review

Anyone except @dcarley