### PR TITLE
Remove the "more info" collapsing section

### DIFF
--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -48,12 +48,10 @@ internals.getStoryViewModel = function(storyDetail, membershipInfo, transitions)
         var workers = story.owner_ids.map(function(worker_id) {
             return personFetcher.mapPersonFromId(worker_id, membershipInfo);
         });
-        var signOffBy = personFetcher.mapPersonFromId(story.requested_by_id, membershipInfo);
         var daysInProgress = internals.calculateDaysInProgress(story.id, story.current_state, transitions);
         return {
             id: story.id,
             name: story.name,
-            signOffBy: signOffBy,
             workers: workers,
             daysInProgress: daysInProgress,
             isBlocked: internals.isBlocked(story),
@@ -156,7 +154,6 @@ function tokenise(play, finished, delivered, rejected) {
             coll.push(story.id);
             coll.push(story.team != undefined ? story.team : 'neutral');
             coll.push(story.status);
-            coll.push(story.signOffBy);
             coll.push(story.workers != undefined ? '[' + story.workers.join(':') + ']' : 'null');
             coll.push('[' + getLabels(story) + ']');
 

--- a/public/css/rubbernecker.css
+++ b/public/css/rubbernecker.css
@@ -156,3 +156,13 @@ div.options label {
 div.options label:last-of-type {
   margin-right: 0;
 }
+
+.story .panel-body .team-lead {
+  align-items: flex-end;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.flex-container {
+  display: flex;
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -59,7 +59,6 @@
                 <%- include('story/summary', {
                     story: story,
                     status: "started",
-                    message: "In Progress",
                     overLimit: false
                 }); %>
             <% }); %>
@@ -77,7 +76,6 @@
                 <%- include('story/summary', {
                     story: story,
                     status: "finished",
-                    message: "In Review",
                     overLimit: reviewSlotsLimit < (key + 1)
                 }); %>
             <% }); %>
@@ -95,7 +93,6 @@
                 <%- include('story/summary', {
                     story: story,
                     status: "delivered",
-                    message: "In Approving",
                     overLimit: approveSlotsLimit < (key + 1)
                 }); %>
             <% }); %>
@@ -109,7 +106,6 @@
                 <%- include('story/summary', {
                     story: story,
                     status: "rejected",
-                    message: "Rejected",
                     overLimit: false
                 }); %>
             <% }); %>

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -24,17 +24,19 @@
                 </h4>
             <% } %>
 
-            <% if (story.workers.length > 0) { %>
-                <div>
-                    <h4>Assignee<%= story.workers.length != 1 ? "s" : "" %></h4>
-                    <p><%= story.workers.join(", "); %></p>
-                </div>
-            <% } %>
+            <div class="row flex-container">
+                <% if (story.workers.length > 0) { %>
+                    <div class="col-md-8">
+                        <h4>Assignee<%= story.workers.length != 1 ? "s" : "" %></h4>
+                        <p><%= story.workers.join(", "); %></p>
+                    </div>
+                <% } %>
 
-            <div class="row">
-                <div class="col-md-6 text-right">
+                <div class="col-md-4 team-lead">
                     <% if (story.lead) { %>
-                        Lead: <strong><%= story.lead %></strong>
+                        <p>
+                            Lead: <strong><%= story.lead %></strong>
+                        </p>
                     <% } %>
                 </div>
             </div>

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -32,29 +32,11 @@
             <% } %>
 
             <div class="row">
-                <div class="col-md-6">
-                    <a href="#<%= story.id %>-info" data-toggle="collapse" aria-expanded="false" aria-controls="<%= story.id %>-info">
-                        More info
-                    </a>
-                </div>
                 <div class="col-md-6 text-right">
                     <% if (story.lead) { %>
                         Lead: <strong><%= story.lead %></strong>
                     <% } %>
                 </div>
-            </div>
-
-            <div id="<%= story.id %>-info" class="collapse">
-                <table class="table table-bordered">
-                    <tr>
-                        <th>Status</th>
-                        <td><%= message %></td>
-                    </tr>
-                    <tr>
-                        <th>Requester</th>
-                        <td><%= story.signOffBy %></td>
-                    </tr>
-                </table>
             </div>
         </div>
 


### PR DESCRIPTION
## What

I was originally going to rename the "signOffBy" variable to indicate that
we no longer require specific people to do story sign-off. But as I got
further into the code I realised that the collapsed details behind the "more
info" button probably aren't very useful to us now either because:

- it doesn't really matter who the original author of the story was,
  especially as stories often get rewritten and each story now has a
  designated lead associated with it
- the status can be determined from which column the story is in

## How to review

1. Run the application using the instructions in the README. I used Docker because I didn't want to install Node:

        docker-machine ssh dev -L 3000:localhost:3000 &
        docker run -ti --rm -v $(pwd):/mnt -w /mnt -p 3000:3000 -e PIVOTAL_PROJECT_ID=1275640 -e PIVOTAL_API_KEY=$(pass pivotal/api_token) node:7-alpine npm start

1. View the application on http://localhost:3000
1. Check that it still renders correctly
1. Check that the JS console in Chrome dev tools doesn't complain about me removing something that I shouldn't have

## Who can review

Anyone except @dcarley