### PR TITLE
Fix the layout

### DIFF
--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -12,25 +12,16 @@
         </div>
 
         <div class="panel-body">
-            <% if (story.workers.length === 0) { %>
-                <h4 class="text-danger">
-                    <% if (story.workers.length === 0) { %>
-                        <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-                    <% } %>
-                    Nobody is working on this
-
-                    <br>
-                    <small>Sad times.</small>
-                </h4>
-            <% } %>
-
             <div class="row flex-container">
-                <% if (story.workers.length > 0) { %>
-                    <div class="col-md-8">
+                <div class="col-md-8">
+                    <% if (story.workers.length > 0) { %>
                         <h4>Assignee<%= story.workers.length != 1 ? "s" : "" %></h4>
                         <p><%= story.workers.join(", "); %></p>
-                    </div>
-                <% } %>
+                    <% } else { %>
+                        <h4 class="text-danger">Nobody is working on this</h4>
+                        <p>Sad times.</p>
+                    <% } %>
+                </div>
 
                 <div class="col-md-4 team-lead">
                     <% if (story.lead) { %>


### PR DESCRIPTION
## What

When no one is assigned to a story, the layout still breaks. This fix will place the message in the same wrapper as the Assignees making it get into line with the story lead.

## How to review

1. Fire the application locally
2. If there are no unassigned stories, make one temporary unassigned
3. See if the team lead is aligned to the bottom right at all times

## Who can review

Not @paroxp