### PR TITLE
Fix the sticker sizes

### DIFF
--- a/public/css/rubbernecker.css
+++ b/public/css/rubbernecker.css
@@ -76,7 +76,11 @@
 .story {
   position: relative;
 }
+.story .panel-footer .sticker {
+  height: 40px;
+}
 .story .panel-footer .sticker img {
+  max-height: 40px;
   max-width: 100%;
 }
 .story .panel-footer .row:not(:last-of-type) {

--- a/views/story/summary.ejs
+++ b/views/story/summary.ejs
@@ -37,11 +37,11 @@
         <div class="panel-footer <%= story.isBlocked || story.hasComments || overLimit ? '' :'hidden' %>">
             <% if (overLimit) { %>
                 <div class="row">
-                    <div class="col-sm-2 sticker">
+                    <div class="col-xs-2 sticker">
                         <img src="/images/sad_panda.gif" alt="Sad Panda" class="img-circle">
                     </div>
 
-                    <div class="col-sm-10 description">
+                    <div class="col-xs-10 description">
                         I am a sad panda.<br/>
                         I will never find any slots for <%= status == 'finished' ? 'review' : 'acceptance' %>.
                     </div>
@@ -50,11 +50,11 @@
 
             <% if (story.isBlocked) { %>
                 <div class="row">
-                    <div class="col-sm-2 sticker">
+                    <div class="col-xs-2 sticker">
                         <img src="/images/blocked.svg" alt="Story Blocked" class="img-circle">
                     </div>
 
-                    <div class="col-sm-10 description">
+                    <div class="col-xs-10 description">
                         Blocked!<br/>
                         See story comments for more details
                     </div>
@@ -63,11 +63,11 @@
 
             <% if (story.hasComments) { %>
                 <div class="row">
-                    <div class="col-sm-2 sticker">
+                    <div class="col-xs-2 sticker">
                         <img src="/images/comments.svg" alt="Story has Comments to Resolve" class="img-circle">
                     </div>
 
-                    <div class="col-sm-10 description">
+                    <div class="col-xs-10 description">
                         Has comments to resolve<br/>
                         See story or pull request for more details
                     </div>


### PR DESCRIPTION
## What

It has been bugging me a lot, that the sticker image could get any size at different window sizes... This fix will lock it down to a static 40px height.

It also fixes the responsive stickers view of the dashboard.

## How to review

1. Fire the app locally
1. Experiment with different window sizes
1. Establish if stickers do not look ugly

## Who can review

Not @paroxp