### PR TITLE
Fix the number of days in play

### DIFF
--- a/lib/personFetcher.js
+++ b/lib/personFetcher.js
@@ -15,7 +15,10 @@ personFetcher.getMembers = function(res, callback) {
 
 	request(options, function getMemberships(error, response, body) {
 		if (!error && response.statusCode == 200) {
-			callback(null, JSON.parse(body));
+			var members = JSON.parse(body);
+			res.app.set('members', members);
+
+			callback(null, members);
 		} else {
 			callback("Couldn't get people thanks to this crap" + response.statusCode, null);
 		}

--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -43,12 +43,12 @@ internals.hasComments = function(story) {
     }
 }
 
-internals.getStoryViewModel = function(storyDetail, membershipInfo, transitions) {
-    var viewModels = storyDetail.map(function(story) {
-        var workers = story.owner_ids.map(function(worker_id) {
+internals.getStoryViewModel = function (membershipInfo, storyDetail, transitions) {
+    var viewModels = storyDetail.map(function (story) {
+        var workers = story.owner_ids.map(function (worker_id) {
             return personFetcher.mapPersonFromId(worker_id, membershipInfo);
         });
-        var daysInProgress = internals.calculateDaysInProgress(story.id, story.current_state, transitions);
+        var daysInProgress = internals.calculateDaysInProgress(story, transitions);
         return {
             id: story.id,
             name: story.name,
@@ -65,7 +65,7 @@ internals.getStoryViewModel = function(storyDetail, membershipInfo, transitions)
 }
 
 internals.getStoriesByStatus = function(res, callback, status) {
-    //Get the list of stories
+    // Get the list of stories
     var options = {
         url: 'https://www.pivotaltracker.com/services/v5/projects/' + res.app.get('pivotalProjectId') + '/stories?date_format=millis&with_state=' + status,
         headers: {
@@ -75,48 +75,76 @@ internals.getStoriesByStatus = function(res, callback, status) {
 
     request(options, function getStories(error, response, body) {
         if (!error && response.statusCode == 200) {
-            callback(null, JSON.parse(body));
+            var stories = res.app.get('stories');
+            stories[status] = JSON.parse(body);
+            res.app.set('stories', stories);
+
+            callback(null, stories[status]);
         } else {
             callback("Couldn't get stories thanks to this crap: " + response.statusCode, null);
         }
     });
 }
 
-internals.getStoryTransitions = function(res, callback) {
-    // making assumption we always do work within 2 weeks. Anything beyond we don't care about
-    var twoWeeksAgoISO8601 = new Date(+new Date - 12096e5).toISOString();
+internals.getStoryTransitions = function(res, cb) {
+    var appStories = res.app.get('stories');
 
-    var options = {
-        url: 'https://www.pivotaltracker.com/services/v5/projects/' + res.app.get('pivotalProjectId') + '/story_transitions?occurred_after=' + twoWeeksAgoISO8601,
-        headers: {
-            'X-TrackerToken': res.app.get('pivotalApiKey')
-        }
-    };
+    var calls = [];
+    var stories = appStories.started
+        .concat(appStories.finished)
+        .concat(appStories.delivered)
+        .concat(appStories.rejected);
 
-    request(options, function getStories(error, response, body) {
-        if (!error && response.statusCode == 200) {
-            callback(null, JSON.parse(body));
-        } else {
-            callback("Couldn't get transitions thanks to this crap: " + response.statusCode, null);
-        }
+    stories.forEach(function (story) {
+        calls.push(function (callback) {
+            var options = {
+                url: 'https://www.pivotaltracker.com/services/v5/projects/' + res.app.get('pivotalProjectId') + '/stories/' + story.id + '/transitions',
+                headers: {
+                    'X-TrackerToken': res.app.get('pivotalApiKey')
+                }
+            };
+
+            request(options, function getStories(error, response, body) {
+                if (!error && response.statusCode == 200) {
+                    callback(null, JSON.parse(body));
+                } else {
+                    callback("Could not load the transitions for the story: " + story.id, transitions);
+                }
+            });
+        });
+    });
+
+    async.parallel(calls, function (err, results) {
+        var transitions = [];
+
+        results.forEach(function (result) {
+            transitions = transitions.concat(result);
+        });
+
+        cb(transitions);
     });
 }
 
-internals.calculateDaysInProgress = function(storyId, storyState, transitions) {
+internals.calculateDaysInProgress = function (story, transitions) {
     // Gather relevant transitions
-    var storyTransitions = transitions.filter(function(transition) {
-        return transition.story_id === storyId && transition.state === storyState;
+    var storyTransitions = transitions.filter(function (transition) {
+        return transition.story_id === story.id && transition.state === story.current_state;
     });
 
     // assume an error until we find a valid value
-    var diffDays = TRANSITION_ERROR_CODE;
+    // var diffDays = TRANSITION_ERROR_CODE;
+    var diffDays,
+        mostRecentTransitionDate;
+
     if (storyTransitions.length > 0) {
-        var mostRecentTransitionDate = new Date(Math.max.apply(null, storyTransitions.map(function(transition) {
+        mostRecentTransitionDate = new Date(Math.max.apply(null, storyTransitions.map(function (transition) {
             return new Date(transition.occurred_at);
         })));
-
-        diffDays = findBusinessDaysInRange(mostRecentTransitionDate, new Date()).length;
+    } else {
+        mostRecentTransitionDate = new Date(story.created_at);
     }
+
+    diffDays = findBusinessDaysInRange(mostRecentTransitionDate, new Date()).length;
 
     if (diffDays < 0) {
         diffDays = 0;
@@ -179,29 +207,29 @@ function tokenise(play, finished, delivered, rejected) {
     }
 }
 
-storyFetcher.getStorySummary = function(req, res) {
-    async.parallel([
-            function(callback) {
-                internals.getStoriesByStatus(res, callback, "started");
-            },
-            function(callback) {
+storyFetcher.getStorySummary = function (req, res) {
+    res.app.set('stories', res.app.get('stories') || {});
+
+    async.parallel(
+        {
+            members: function (callback) {
                 personFetcher.getMembers(res, callback);
             },
-            function(callback) {
+            started: function (callback) {
+                internals.getStoriesByStatus(res, callback, "started");
+            },
+            finished: function (callback) {
                 internals.getStoriesByStatus(res, callback, "finished");
             },
-            function(callback) {
+            delivered: function (callback) {
                 internals.getStoriesByStatus(res, callback, "delivered");
             },
-            function(callback) {
+            rejected: function (callback) {
                 internals.getStoriesByStatus(res, callback, "rejected");
-            },
-            function(callback) {
-                internals.getStoryTransitions(res, callback);
             }
-        ],
+        },
         // Combine the results of the things above
-        function(err, results) {
+        function (err, results) {
             if (err) {
                 res.render('damn', {
                     message: '┬──┬◡ﾉ(° -°ﾉ)',
@@ -209,38 +237,44 @@ storyFetcher.getStorySummary = function(req, res) {
                     reason: "(╯°□°）╯︵ ┻━┻"
                 });
             } else {
-                var state = req.get('x-rubbernecker-state');
+                async.parallel([
+                    function (callback) {
+                        internals.getStoryTransitions(res, callback);
+                    }
+                ], function (transitions) {
+                    var state = req.get('x-rubbernecker-state');
 
-                var startedStories = internals.getStoryViewModel(results[0], results[1], results[5]);
-                var finishedStories = internals.getStoryViewModel(results[2], results[1], results[5]);
-                var deliveredStories = internals.getStoryViewModel(results[3], results[1], results[5]);
-                var rejectedStories = internals.getStoryViewModel(results[4], results[1], results[5]);
-                var reviewSlotsLimit = res.app.get('reviewSlotsLimit');
-                var approveSlotsLimit = res.app.get('signOffSlotsLimit');
-                var reviewSlotsFull = reviewSlotsLimit < finishedStories.length;
-                var approveSlotsFull = approveSlotsLimit < deliveredStories.length;
-                var currentState = tokenise(startedStories, finishedStories, deliveredStories, rejectedStories);
+                    var startedStories = internals.getStoryViewModel(results.members, results.started, transitions);
+                    var finishedStories = internals.getStoryViewModel(results.members, results.finished, transitions);
+                    var deliveredStories = internals.getStoryViewModel(results.members, results.delivered, transitions);
+                    var rejectedStories = internals.getStoryViewModel(results.members, results.rejected, transitions);
+                    var reviewSlotsLimit = res.app.get('reviewSlotsLimit');
+                    var approveSlotsLimit = res.app.get('signOffSlotsLimit');
+                    var reviewSlotsFull = reviewSlotsLimit < finishedStories.length;
+                    var approveSlotsFull = approveSlotsLimit < deliveredStories.length;
+                    var currentState = tokenise(startedStories, finishedStories, deliveredStories, rejectedStories);
 
-                if (state != undefined) {
-                    res.setHeader('Content-Type', 'application/json');
-                    res.send(JSON.stringify({
-                        state: state === currentState ? 'clean' : 'dirty'
-                    }));
+                    if (state != undefined) {
+                        res.setHeader('Content-Type', 'application/json');
+                        res.send(JSON.stringify({
+                            state: state === currentState ? 'clean' : 'dirty'
+                        }));
 
-                    return;
-                }
+                        return;
+                    }
 
-                res.render('index', {
-                    projectId: res.app.get('pivotalProjectId'),
-                    story: startedStories,
-                    finishedStory: finishedStories,
-                    deliveredStory: deliveredStories,
-                    rejectedStory: rejectedStories,
-                    reviewSlotsLimit: reviewSlotsLimit,
-                    approveSlotsLimit: approveSlotsLimit,
-                    reviewSlotsFull: reviewSlotsFull,
-                    approveSlotsFull: approveSlotsFull,
-                    currentState: currentState
+                    res.render('index', {
+                        projectId: res.app.get('pivotalProjectId'),
+                        story: startedStories,
+                        finishedStory: finishedStories,
+                        deliveredStory: deliveredStories,
+                        rejectedStory: rejectedStories,
+                        reviewSlotsLimit: reviewSlotsLimit,
+                        approveSlotsLimit: approveSlotsLimit,
+                        reviewSlotsFull: reviewSlotsFull,
+                        approveSlotsFull: approveSlotsFull,
+                        currentState: currentState
+                    });
                 });
             }
         });


### PR DESCRIPTION
## What

The current approach is, that we do not care for stories that took
longer than two weeks. WRONG! We've got more of these recently, and it
would be useful, to have an actual corresponding number.

It's a little bit of a pain, to calculate these correctly. I took the
approach, of doing that after all the stories have been collected. Each
of the story, then will call the API for it's own transitions over time
and the days will be calculated from that. It means, there is a slight
increase of API, CPU and Memory usage. It also increases the
rubbernecker response time. I am not proud about any of these, but it's
a terrible hack we have to live with, if we'd like to be precise.

This commit, also covers some minor clean up and change of some
approaches.

## How to review

It may be a difficult thing to review, if there are no stories old enough. The code review may not be easy either, since we're following bad practices through out the project, it's to late to change bit's and pieces.

Run the application
See if the counter doesn't display `0 days`

## Who can review

Not @paroxp