### PR TITLE
Order the support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,25 @@ It organises things by status, displays simple information about each story, who
 
 Clone this repo
 
-``` 
+```
 npm install
 ```
 
 ## Running
 After completing above installation instructions, to run locally without Basic Authentication:
 
-``` 
-DEBUG=rubbernecker:* PIVOTAL_API_KEY=your-api-key PIVOTAL_PROJECT_ID=your-project-id npm start
+```
+DEBUG=rubbernecker:* PIVOTAL_API_KEY=your-api-key PIVOTAL_PROJECT_ID=your-project-id PAGERDUTY_API_TOKEN=your-pagerduty-token npm start
 ```
 
 If you want to try out the stunning Basic Auth (useful for when you don't want everyone getting straight to your story overviews)
-``` 
-DEBUG=rubbernecker:* PIVOTAL_API_KEY=your-api-key PIVOTAL_PROJECT_ID=your-project-id USE_AUTH=true USERNAME=username PASSWORD=password npm start
 ```
+DEBUG=rubbernecker:* PIVOTAL_API_KEY=your-api-key PIVOTAL_PROJECT_ID=your-project-id PAGERDUTY_API_TOKEN=your-pagerduty-token USE_AUTH=true USERNAME=username PASSWORD=password npm start
+```
+
+#### PagerDuty Support
+
+Rubbernecker **optionally** supports PagerDuty, for pulling out the current rota information. This requires a `PAGERDUTY_API_TOKEN` environment variable, to be passed before the app is run.
 
 ### Deploying
 I've been deploying this to cloud foundry so I use the following manifest file:
@@ -38,6 +42,7 @@ applications:
   env:
     PIVOTAL_API_KEY: API KEY GOES HERE
     PIVOTAL_PROJECT_ID: PROJECT ID GOES HERE
+    PAGERDUTY_API_TOKEN: PAGERDUTY TOKEN GOES HERE
     USE_AUTH: true
     USERNAME: sensible username goes here
     PASSWORD: sensible long password goes here

--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -167,21 +167,32 @@ internals.getSupportDetails = function (res, cb) {
 
             obj.oncalls.forEach(function (oncall) {
                 if (oncall.schedule) {
-                    list[oncall.schedule.summary] = {
-                        schedule: oncall.schedule.summary.replace("PaaS team rota", "Rota").replace("PaaS team ", ""),
+                    var name = parseName(oncall.schedule.summary);
+                    list[name] = {
+                        schedule: name,
                         user: oncall.user.summary
                     };
                 }
             });
 
-            var hash = Object.keys(list).map(function (key) { return list[key]; });
-
-            cb(null, hash);
+            cb(null, [list["In hours"], list["Out of hours"], list["Escalations"]]);
             return;
         }
 
         cb(null, null);
     });
+
+    //////////
+
+    function parseName(name) {
+        name = name.replace("PaaS team rota - ", "").replace("PaaS team ", "");
+
+        if (name.indexOf("Escalations") != -1) {
+            name = "Escalations";
+        }
+
+        return name.charAt(0).toUpperCase() + name.slice(1);
+    }
 }
 
 function tokenise(play, finished, delivered, rejected) {


### PR DESCRIPTION
## What

At the moment, these fields are showing up at random order. Thinking of
muscle memory, we should probably keep them in the same order at all
times.

We're also simplifying the wording on these, making fields use less
space.

Simple hack...

## How to review

There isn't really a good way, to test the actual order of items due to the PagerDuty API doing it's own thing.

The order should be: **In hours**, **Out of hours**, **Escalations**.

- Code review
- Run the app and see if the new wording is OK