### PR TITLE
Fix the undefined transitions variable

### DIFF
--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -100,7 +100,7 @@ internals.getStoryTransitions = function(res, cb) {
                 if (!error && response.statusCode == 200) {
                     callback(null, JSON.parse(body));
                 } else {
-                    callback("Could not load the transitions for the story: " + story.id, transitions);
+                    callback("Could not load the transitions for the story: " + story.id + " due to: " + response.statusCode, null);
                 }
             });
         });


### PR DESCRIPTION
## What

We're using an undefined variable in the code when trying to error out.
We're going to return a null in that scenario, which will cause
rubbernecker to throw an error page.

Fixes #22

## How to review

Code review should be enough.