### PR TITLE
Check if the transition exists

### DIFF
--- a/lib/storyFetcher.js
+++ b/lib/storyFetcher.js
@@ -120,6 +120,10 @@ internals.getStoryTransitions = function(res, cb) {
 internals.calculateDaysInProgress = function (story, transitions) {
     // Gather relevant transitions
     var storyTransitions = transitions.filter(function (transition) {
+        if (transition === null || typeof transition === "undefined") {
+            return false;
+        }
+
         return transition.story_id === story.id && transition.state === story.current_state;
     });
 


### PR DESCRIPTION
## What

The Pivotal API returns an array of transitions, which is then used to
calculate number of days in current state. It would appear, it also
returns a `null` value, which simply kills our application.

We're now checking if the value returned by an API is not `null` nor
undefined type.

## How to review

Sanity check would be sufficient enough.
We cannot really force Pivotal to return a fault causing item.