### PR TITLE
Remove docker environment checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,28 +6,30 @@ DOCKER_COMPOSE = $(shell command -v docker-compose)
 GO     := $(if $(shell command -v go),go,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) golang:1.9 go)
 GOLINT := $(if $(shell command -v golint),golint,$(GO) get -u github.com/golang/lint/golint && golint)
 NPM    := $(if $(shell command -v npm),npm,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) node:carbon-alpine npm)
+DEP    := $(if $(shell command -v dep),dep,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) golang:1.9 dep)
 
 build: scripts styles compile
 
 check_evn:
 	$(if $(DOCKER),,$(error "docker not found in PATH"))
 
-compile: check_evn
+compile:
 	$(GO) build -o bin/rubbernecker
 
 dependencies:
 	$(NPM) install
+	$(DEP) ensure
 
-lint: check_evn
+lint:
 	$(GO) fmt ./...
 	$(GO) vet ./...
 	$(GOLINT) . pkg/...
 	$(NPM) run tslint
 
-scripts: check_evn
+scripts:
 	$(NPM) run tsc
 
-styles: check_evn
+styles:
 	$(NPM) run sass
 
 test:


### PR DESCRIPTION
Remove docker enviroment checks from every command in makefile.  Retaining the check command, but removing dependency of other commands such as compile on this, as if GO is installed already we don't actually need docker.