### PR TITLE
[#156648883] Fix rota and blocker appearance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: go
-services:
-  - redis-server
-env:
-  - DEP_VERSION="0.3.2" REDIS_URL="localhost:6379"
-before_install:
-  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
-  - chmod +x $GOPATH/bin/dep
-install:
-  - dep ensure -vendor-only
 go:
-  - 1.8.x
   - 1.9.x
   - master
+before_install:
+  - go get -u github.com/golang/dep/cmd/dep
+install:
+  - dep ensure -vendor-only
+script:
+  - go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 RUBBERNECKER_DIR=$(shell pwd)
 
-DOCKER         = $(shell command -v docker)
+DOCKER = $(shell command -v docker)
 
 GO     := $(if $(shell command -v go),go,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) golang:1.9 go)
 GOLINT := $(if $(shell command -v golint),golint,$(GO) get -u github.com/golang/lint/golint && golint)

--- a/main.go
+++ b/main.go
@@ -153,9 +153,9 @@ func fetchUsers(pt *pivotal.Tracker) error {
 
 func formatSupportNames(s rubbernecker.SupportRota) rubbernecker.SupportRota {
 	return rubbernecker.SupportRota{
-		"in-hours":     s["PaaS team rota - in hours"],
-		"out-of-hours": s["PaaS team rota - out of hours"],
-		"escalations":  s["PaaS team Escalations - out of hours"],
+		"in-hours":     s.Get("PaaS team rota - in hours"),
+		"out-of-hours": s.Get("PaaS team rota - out of hours"),
+		"escalations":  s.Get("PaaS team Escalations - out of hours"),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ func main() {
 		log.Debug("Team Members have been fetched.")
 	})
 
-	scheduler.Every(6).Hours().Run(func() {
+	scheduler.Every(5).Minutes().Run(func() {
 		err := fetchSupport(pd)
 		if err != nil {
 			log.Error(err)

--- a/pkg/pagerduty/support.go
+++ b/pkg/pagerduty/support.go
@@ -26,8 +26,8 @@ func New(token string) *Schedule {
 // storing it in the Schedule for future use.
 func (p *Schedule) FetchSupport() error {
 	opts := pd.ListOnCallOptions{
-		Since: time.Now().Add(-24 * time.Hour).String(),
-		Until: time.Now().String(),
+		Since: time.Now().String(),
+		Until: time.Now().Add(24 * time.Hour).String(),
 	}
 
 	res, err := p.Client.ListOnCalls(opts)

--- a/pkg/pivotal/internal.go
+++ b/pkg/pivotal/internal.go
@@ -127,3 +127,13 @@ func convertState(state string) string {
 		return "unknown"
 	}
 }
+
+func hasUnresolvedBlockers(blockers []blocker) bool {
+	for _, blocker := range blockers {
+		if !blocker.Resolved {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/pivotal/story.go
+++ b/pkg/pivotal/story.go
@@ -83,7 +83,7 @@ func (t *Tracker) FlattenStories() (rubbernecker.Cards, error) {
 			}
 		}
 
-		if len(s.Blockers) > 0 && stickers.Get("blocked") == nil {
+		if hasUnresolvedBlockers(s.Blockers) && stickers.Get("blocked") == nil {
 			if sticker := t.stickers.Get("blocked"); sticker != nil {
 				stickers = append(stickers, sticker)
 			}

--- a/pkg/rubbernecker/support.go
+++ b/pkg/rubbernecker/support.go
@@ -9,6 +9,17 @@ type Support struct {
 // SupportRota will contain a unique list prefixed with a type of support.
 type SupportRota map[string]*Support
 
+// Get returns with the given key or an empty value
+func (s SupportRota) Get(key string) *Support {
+	if support, ok := s[key]; ok {
+		return support
+	}
+	return &Support{
+		Type:   key,
+		Member: "-",
+	}
+}
+
 // SupportService interface will establish a standard for any extension handling
 // support data.
 type SupportService interface {


### PR DESCRIPTION
## What

At current, it is set to every 6 hours. It's very generous. I'm sure the
API can handle more frequent calls, like every 5 minutes - which is
still pretty generous, however will prevent us from experience a "bug",
causing confusion of who's currently on the rota.

Also the sticker would appear if there have been resolved blockers
on the story. This isn't desired behaviour.

The API provides us with a resolved boolean which we can validate when
checking if story is STILL blocked.

## How to review

- Build and run the application `make build && ./bin/rubbernecker`
- Visit `localhost:8080`
- _tricky_: Setup a schedule override for in hours (15 min should be fine) and see if your local app updates in around 5 minutes
- Play with blockers and see if they have correct behaviour