### PR TITLE
[[#156691837] Have a per team rubbernecker view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ RUBBERNECKER_DIR=$(shell pwd)
 
 DOCKER = $(shell command -v docker)
 
-GO     := $(if $(shell command -v go),go,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) golang:1.9 go)
-GOLINT := $(if $(shell command -v golint),golint,$(GO) get -u github.com/golang/lint/golint && golint)
-NPM    := $(if $(shell command -v npm),npm,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) node:carbon-alpine npm)
+GO     := $(if $(shell which go),go,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) golang:1.9 go)
+GOLINT := $(if $(shell which golint),golint,$(GO) get -u github.com/golang/lint/golint && golint)
+NPM    := $(if $(shell which npm),npm,docker run --rm -v $(RUBBERNECKER_DIR):$(RUBBERNECKER_DIR) -w $(RUBBERNECKER_DIR) node:carbon-alpine npm)
 
 build: scripts styles compile
 

--- a/build/scss/_card.scss
+++ b/build/scss/_card.scss
@@ -93,6 +93,7 @@ $spacing: 16px;
       display: flex;
       flex-direction: row-reverse;
       width: 75%;
+      text-transform: capitalize;
 
       > div {
         display: inline-block;

--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -215,8 +215,14 @@ class Application {
         .empty();
 
       for (const sticker of card.stickers) {
+        const stickerClass = sticker.Class !== '' ? ` sticker-${sticker.Class}` : '';
+        const classAttribute = `sticker-${sticker.Name}${stickerClass}`;
+        const stickerContent = sticker.Image === '' ?
+              sticker.Title :
+              `<img src="${sticker.Image}" alt="${sticker.Title}" title="${sticker.Title}">`;
+
         $stickers
-          .append(sticker.Image == ""? `<div>${sticker.Title}</div>` : `<div><img src="${sticker.Image}" alt="${sticker.Title}" title="${sticker.Title}"></div>`);
+          .append(`<div class="${classAttribute}">${stickerContent}</div>`);
       }
     }
 

--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -146,6 +146,22 @@ class Application {
       .on(State.updated, () => { this.parseContent(); });
   }
 
+  public filterTeam(name: string) {
+    const anyTeamCards = $('.card:not(:has(.sticker-team))');
+    this.gracefulIn(anyTeamCards);
+
+    const teamCards = $('.card:has(.sticker-team)')
+    const visibleTeamCards = teamCards.filter(`:has(.sticker-team-${name})`)
+    const hiddenTeamCards = teamCards.filter(`:not(:has(.sticker-team-${name}))`)
+
+    this.gracefulIn(visibleTeamCards);
+    this.gracefulOut(hiddenTeamCards);
+  }
+
+  public resetFilter() {
+    this.gracefulIn($('.card'));
+  }
+
   private async parseContent() {
     if (!this.state.content.cards) {
       console.error('No cards found in state...');

--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -216,7 +216,7 @@ class Application {
 
       for (const sticker of card.stickers) {
         $stickers
-          .append(`<div><img src="${sticker.Image}" alt="${sticker.Title}" title="${sticker.Title}"></div>`);
+          .append(sticker.Image == ""? `<div>${sticker.Title}</div>` : `<div><img src="${sticker.Image}" alt="${sticker.Title}" title="${sticker.Title}"></div>`);
       }
     }
 

--- a/build/views/index.html
+++ b/build/views/index.html
@@ -23,6 +23,10 @@
       <li><strong>Out of hours</strong>: <em class="out-of-hours">{{(index .SupportRota "out-of-hours").Member}}</em></li>
       <li><strong>Escalations</strong>: <em class="escalations">{{(index .SupportRota "escalations").Member}}</em></li>
     </ul>
+    <button onclick="app.filterTeam('a')">Team A</button>
+    <button onclick="app.filterTeam('b')">Team B</button>
+    <button onclick="app.filterTeam('c')">Team C</button>
+    <button onclick="app.resetFilter()">Show all</button>
   </header>
 
   <main class="row">

--- a/build/views/sticker.html
+++ b/build/views/sticker.html
@@ -1,5 +1,9 @@
 {{define "sticker"}}
   <div>
+    {{if .Image}}
     <img src="{{.Image}}" alt="{{.Title}}" title="{{.Title}}">
+    {{else}}
+    {{.Title}}
+    {{end}}
   </div>
 {{end}}

--- a/build/views/sticker.html
+++ b/build/views/sticker.html
@@ -1,5 +1,5 @@
 {{define "sticker"}}
-  <div>
+  <div class="sticker-{{.Name}}{{if .Class}} sticker-{{.Class}}{{end}}">
     {{if .Image}}
     <img src="{{.Image}}" alt="{{.Title}}" title="{{.Title}}">
     {{else}}

--- a/pkg/rubbernecker/response.go
+++ b/pkg/rubbernecker/response.go
@@ -40,9 +40,7 @@ func (r *Response) Template(code int, w http.ResponseWriter, templateFile ...str
 		return err
 	}
 
-	t.Execute(w, r)
-
-	return nil
+	return t.Execute(w, r)
 }
 
 // WithCards will set a collection/single card for the current response.

--- a/pkg/rubbernecker/sticker.go
+++ b/pkg/rubbernecker/sticker.go
@@ -1,8 +1,11 @@
 package rubbernecker
 
+import "regexp"
+
 // Sticker is a rubbernecker definition of labels.
 type Sticker struct {
 	Name    string
+	Regex   string
 	Title   string
 	Image   string
 	Content string
@@ -14,6 +17,17 @@ type Stickers []*Sticker
 
 // Matches will check if the sticker matches the query provided by the extension.
 func (s *Sticker) Matches(query string) *Sticker {
+	if s.Regex != "" {
+		reg := regexp.MustCompile(s.Regex)
+		if reg.MatchString(query) {
+			sticker := *s
+			sticker.Title = reg.ReplaceAllString(query, sticker.Title)
+			sticker.Image = reg.ReplaceAllString(query, sticker.Image)
+			sticker.Content = reg.ReplaceAllString(query, sticker.Content)
+			return &sticker
+		}
+	}
+
 	if s.Name == query {
 		return s
 	}

--- a/pkg/rubbernecker/sticker.go
+++ b/pkg/rubbernecker/sticker.go
@@ -10,6 +10,7 @@ type Sticker struct {
 	Image   string
 	Content string
 	Aliases []string
+	Class   string
 }
 
 // Stickers is a simple slice of stickers
@@ -24,6 +25,7 @@ func (s *Sticker) Matches(query string) *Sticker {
 			sticker.Title = reg.ReplaceAllString(query, sticker.Title)
 			sticker.Image = reg.ReplaceAllString(query, sticker.Image)
 			sticker.Content = reg.ReplaceAllString(query, sticker.Content)
+			sticker.Class = reg.ReplaceAllString(query, sticker.Class)
 			return &sticker
 		}
 	}

--- a/pkg/rubbernecker/sticker.go
+++ b/pkg/rubbernecker/sticker.go
@@ -12,7 +12,7 @@ type Sticker struct {
 // Stickers is a simple slice of stickers
 type Stickers []*Sticker
 
-// Matches will check if the sticker mathes the query provided by the extension.
+// Matches will check if the sticker matches the query provided by the extension.
 func (s *Sticker) Matches(query string) *Sticker {
 	if s.Name == query {
 		return s

--- a/pkg/rubbernecker/sticker_test.go
+++ b/pkg/rubbernecker/sticker_test.go
@@ -37,28 +37,29 @@ var _ = Describe("Response", func() {
 		BeforeEach(func() {
 			sticker = rubbernecker.Sticker{
 				Name:    "test",
-				Regex:   "team: ([a-zA-Z])$",
-				Title:   "Team $1",
+				Regex:   "test: ([a-zA-Z])$",
+				Title:   "Test $1",
 				Image:   "/test_$1.png",
 				Content: "Only a test. Not to worry! $1",
 				Aliases: []string{"tset", "trial"},
+				Class:   "class-$1",
 			}
 		})
 
 		It("should check if the sticker Matches() regex", func() {
-			Expect(sticker.Matches("team: a")).NotTo(BeNil())
-			Expect(sticker.Matches("team: foo")).To(BeNil())
+			Expect(sticker.Matches("test: a")).NotTo(BeNil())
+			Expect(sticker.Matches("test: foo")).To(BeNil())
 		})
 
 		It("should expand submatches of Regex in all the UI fields", func() {
-			s := sticker.Matches("team: a")
+			s := sticker.Matches("test: a")
 			Expect(s).NotTo(BeNil())
-			Expect(s.Title).To(Equal("Team a"))
+			Expect(s.Title).To(Equal("Test a"))
 			Expect(s.Image).To(Equal("/test_a.png"))
 			Expect(s.Content).To(Equal("Only a test. Not to worry! a"))
+			Expect(s.Class).To(Equal("class-a"))
 		})
 	})
-
 
 	It("should establish if the list Has() specific sticker", func() {
 		ss := rubbernecker.Stickers{&sticker}

--- a/pkg/rubbernecker/sticker_test.go
+++ b/pkg/rubbernecker/sticker_test.go
@@ -33,6 +33,33 @@ var _ = Describe("Response", func() {
 		Expect(sticker.Matches("testing")).To(BeNil())
 	})
 
+	Context("when using Regexs", func() {
+		BeforeEach(func() {
+			sticker = rubbernecker.Sticker{
+				Name:    "test",
+				Regex:   "team: ([a-zA-Z])$",
+				Title:   "Team $1",
+				Image:   "/test_$1.png",
+				Content: "Only a test. Not to worry! $1",
+				Aliases: []string{"tset", "trial"},
+			}
+		})
+
+		It("should check if the sticker Matches() regex", func() {
+			Expect(sticker.Matches("team: a")).NotTo(BeNil())
+			Expect(sticker.Matches("team: foo")).To(BeNil())
+		})
+
+		It("should expand submatches of Regex in all the UI fields", func() {
+			s := sticker.Matches("team: a")
+			Expect(s).NotTo(BeNil())
+			Expect(s.Title).To(Equal("Team a"))
+			Expect(s.Image).To(Equal("/test_a.png"))
+			Expect(s.Content).To(Equal("Only a test. Not to worry! a"))
+		})
+	})
+
+
 	It("should establish if the list Has() specific sticker", func() {
 		ss := rubbernecker.Stickers{&sticker}
 

--- a/stickers.yml
+++ b/stickers.yml
@@ -22,7 +22,9 @@
 - name: team
   regex: 'team:?\s*([a-zA-Z0-9\s]+)'
   title: 'Team $1'
+  class: 'team-$1'
 
 - name: lead
   regex: 'lead:?\s*([a-zA-Z0-9\s]+)'
   title: 'Lead $1'
+  class: 'lead-$1'

--- a/stickers.yml
+++ b/stickers.yml
@@ -18,3 +18,11 @@
   image: /img/sad_panda.gif
   title: Sad Panda
   content: "I am a sad panda.<br/>I will never find any slots for progress."
+
+- name: team
+  regex: 'team:?\s*([a-zA-Z0-9\s]+)'
+  title: 'Team $1'
+
+- name: lead
+  regex: 'lead:?\s*([a-zA-Z0-9\s]+)'
+  title: 'Lead $1'


### PR DESCRIPTION
[#156691837 Have a per team rubbernecker view](https://www.pivotaltracker.com/story/show/156691837)

What?
-----

We need to have a way for a sub-team on PaaS to be able to see the pivotal stories which are relevant to them during standup and when checking what is in play for pairing/starting something new.

In this PR we implement the capability of show any label as stickerts
based on regex, display stickers without image as text, and
add HTML class to the stickers for filtering with jQuery.

Finally we add hardcoded buttons to filter per team.

Out of scope
-------------

We decided leave out of scope:

 - Make this pretty, like separating text/image stickers
 - Generate filter buttons dynamically

How to review:
-------------

Code review.

Compile it and run it (remember to wait 20s the after start):

```
make dependencies
make build

PIVOTAL_TRACKER_API_TOKEN=$(paas-pass pivotal/tracker_token) \
PIVOTAL_TRACKER_PROJECT_ID=1275640 \
PAGERDUTY_AUTHTOKEN=$(paas-pass pagerduty/rubbernecker_api_token) \
./bin/rubbernecker
```

go to http://localhost:8080

Who?
----

Not @keymon or @henrytk