### PR TITLE
Anchor regexes for team and lead stickers

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -20,11 +20,11 @@
   content: "I am a sad panda.<br/>I will never find any slots for progress."
 
 - name: team
-  regex: 'team:?\s*([a-zA-Z0-9\s]+)'
+  regex: '^team:?\s*([a-zA-Z0-9\s]+)'
   title: 'Team $1'
   class: 'team-$1'
 
 - name: lead
-  regex: 'lead:?\s*([a-zA-Z0-9\s]+)'
+  regex: '^lead:?\s*([a-zA-Z0-9\s]+)'
   title: 'Lead $1'
   class: 'lead-$1'


### PR DESCRIPTION
## What

So that they only match labels that begin with `team` or `lead` rather
than anywhere in the label. This will fix a bug where it was applying
`class="sticker-team sticker-documentation - team-manual"` to a story
with a label of `documentation - team manual`.

Before:

![screen shot 2018-05-01 at 14 11 13](https://user-images.githubusercontent.com/260438/39474078-102cdd3c-4d4a-11e8-9430-822249900c60.png)

After:

![screen shot 2018-05-01 at 14 11 19](https://user-images.githubusercontent.com/260438/39474079-128c3078-4d4a-11e8-8885-9cff76e977a0.png)

## How to review

Code review might be sufficient.

Or you can check it yourself with the following command whilst [#156658598](https://www.pivotaltracker.com/n/projects/1275640/stories/156658598) is still in review:
```
make dependencies && make build && env PIVOTAL_TRACKER_PROJECT_ID=1275640 PIVOTAL_TRACKER_API_TOKEN=$(PASSWORD_STORE_DIR=~/.paas-pass pass pivotal/rubbernecker_api_token) PAGERDUTY_AUTHTOKEN=$(PASSWORD_STORE_DIR=~/.paas-pass pass pagerduty/rubbernecker_api_token) ./bin/rubbernecker
```

## Who can review

Anyone.