### PR TITLE
Reset state after time lapse

### DIFF
--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -67,9 +67,12 @@ class State {
   }
 }
 
+const RESET_FILTERS_TIMEOUT_MS = 30 * 60 * 1000;
+
 class Application {
   public static updated: string = 'rubbernecker:application:updated';
 
+  public filterResetTimeout: any;
   private state: State;
 
   constructor() {
@@ -156,10 +159,15 @@ class Application {
 
     this.gracefulIn(visibleTeamCards);
     this.gracefulOut(hiddenTeamCards);
+
+    this.filterResetTimeout = setTimeout(() => {
+      $('input[name=all]').parents('label').trigger('click');
+    }, RESET_FILTERS_TIMEOUT_MS);
   }
 
   public resetFilter() {
     this.gracefulIn($('.card'));
+    clearTimeout(this.filterResetTimeout);
   }
 
   private async parseContent() {

--- a/build/views/index.html
+++ b/build/views/index.html
@@ -24,11 +24,19 @@
       <li><strong>Escalations</strong>: <em class="escalations">{{(index .SupportRota "escalations").Member}}</em></li>
     </ul>
 
-    <div class="btn-group btn-group">
-      <button class="btn btn-outline-dark btn-sm" onclick="app.filterTeam('a')">Team A</button>
-      <button class="btn btn-outline-dark btn-sm" onclick="app.filterTeam('b')">Team B</button>
-      <button class="btn btn-outline-dark btn-sm" onclick="app.filterTeam('c')">Team C</button>
-      <button class="btn btn-outline-dark btn-sm" onclick="app.resetFilter()">Show all</button>
+    <div class="btn-group btn-group-toggle" data-toggle="buttons">
+      <label class="btn btn-outline-dark btn-sm" onclick="app.filterTeam('a')">
+        <input type="radio" name="a" autocomplete="off"> Team A
+      </label>
+      <label class="btn btn-outline-dark btn-sm" onclick="app.filterTeam('b')">
+        <input type="radio" name="b" autocomplete="off"> Team B
+      </label>
+      <label class="btn btn-outline-dark btn-sm" onclick="app.filterTeam('c')">
+        <input type="radio" name="c" autocomplete="off"> Team C
+      </label>
+      <label class="btn btn-outline-dark btn-sm active" onclick="app.resetFilter()">
+        <input type="radio" name="all" autocomplete="off" checked> Show all
+      </label>
     </div>
   </header>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,12 @@
         "tslib": "1.9.0"
       }
     },
+    "@types/jquery": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.4.tgz",
+      "integrity": "sha512-KqgLNDh8oTl43/2B78S7tjwPnOxPtP9wQsLptbuQCmMwqH5QuPZOk36RsNgbs3mnq/3SCyG1l/GJmhKk5Dg68g==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
+    "@types/jquery": "^3.3.4",
     "node-sass": "4.9.0",
     "tslint": "5.10.0",
     "tslint-consistent-codestyle": "1.13.1",


### PR DESCRIPTION
## What

It would be nice to establish which filter is currently active. This can
be achieved with the Bootstrap framework, but requires us to convert
into radio boxes.

As the board is constantly on the view, we'd like for it to
automatically reset it's filters after some time, which would eliminate
the need of human interaction.

We're setting it to 30 minutes, as it's twice as much time, as our
standup would take. Bear in mind, the TMP commit sets it to 10s.

## How to review

- Run the application `make dependencies build && ./bin/rubbernecker`
- Change filters and wait for 10s
- Experience the board switching back to "All"
- Remove the TMP commit.