### PR TITLE
Pull on call rotas page by page

### DIFF
--- a/pkg/helpers/httpmock.go
+++ b/pkg/helpers/httpmock.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"net/http"
+
+	httpmock "gopkg.in/jarcoal/httpmock.v1"
+)
+
+// Returns a responder that iterates across multiple responders in sequence
+func NewCycleResponder(responderCycle ...httpmock.Responder) httpmock.Responder {
+	i := 0
+	return func(req *http.Request) (*http.Response, error) {
+		r := responderCycle[i]
+		i = (i + 1) % len(responderCycle)
+		return r(req)
+	}
+}

--- a/pkg/pagerduty/support.go
+++ b/pkg/pagerduty/support.go
@@ -26,16 +26,26 @@ func New(token string) *Schedule {
 // storing it in the Schedule for future use.
 func (p *Schedule) FetchSupport() error {
 	opts := pd.ListOnCallOptions{
+		APIListObject: pd.APIListObject{
+			Limit:  100,
+			Offset: 0,
+		},
 		Since: time.Now().String(),
 		Until: time.Now().Add(24 * time.Hour).String(),
 	}
 
-	res, err := p.Client.ListOnCalls(opts)
-	if err != nil {
-		return err
-	}
+	for {
+		res, err := p.Client.ListOnCalls(opts)
+		if err != nil {
+			return err
+		}
 
-	p.content = res.OnCalls
+		p.content = append(p.content, res.OnCalls...)
+		if !res.More {
+			break
+		}
+		opts.Offset = opts.Offset + opts.Limit
+	}
 
 	return nil
 }


### PR DESCRIPTION
Now we have lots of teams in pagerduty, oncalls returns a lot
of entries and paginates it.

We increase the number of items to retrieve to each call to 100
and keep retrieving each page if there are still more than
that.