### PR TITLE
Override the content field instead of appending new values

### DIFF
--- a/pkg/pagerduty/support.go
+++ b/pkg/pagerduty/support.go
@@ -34,18 +34,21 @@ func (p *Schedule) FetchSupport() error {
 		Until: time.Now().Add(24 * time.Hour).String(),
 	}
 
+	var content []pd.OnCall
 	for {
 		res, err := p.Client.ListOnCalls(opts)
 		if err != nil {
 			return err
 		}
 
-		p.content = append(p.content, res.OnCalls...)
+		content = append(content, res.OnCalls...)
 		if !res.More {
 			break
 		}
 		opts.Offset = opts.Offset + opts.Limit
 	}
+
+	p.content = content
 
 	return nil
 }


### PR DESCRIPTION
# What

Override the content field instead of appending new values.

The FlattenSupport method will go through the OnCall list and will fetch the first values for any value of oncall.Schedule.Summary. Any updated values will be ignored.

Also we'll also run out of memory if Rubbernecker runs long enough :)

Edit: yes, it ran out of memory at least once:

```
2018-11-07T21:47:56.00+0000   app.crash                  rubbernecker                                                              index: 0, reason: CRASHED, cell_id: de23e6f2-8328-453c-8aa7-7ce9f7db592a, instance: e9c42afa-8fa0-40bf-5791-7b05, exit_description: APP/PROC/WEB: Exited with status 137 (out of memory)
```

# How to review

I ran it locally and it still worked.

# Who can review it

Not me.