### PR TITLE
Fix 'small' task sticker label.

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -9,7 +9,7 @@
   title: Story has Comments to Resolve
   content: "Has comments to resolve<br/>See story or pull request for more details."
 
-- name: small
+- name: "'small' task"
   image: /img/small.png
   title: It's a small task
   content: "Presumably, it's a small task.<br/>Something for support or not requiring a pair."


### PR DESCRIPTION
## What

The label was changed a while ago, but the stickers config was never
updated to reflect this.

## How to review

Verify the label name matches the label we actually use.

## Who can review

Not me.