### PR TITLE
[#163589987] Add Next column to show backlog stories

### DIFF
--- a/build/scss/_card.scss
+++ b/build/scss/_card.scss
@@ -23,6 +23,10 @@ $spacing: 16px;
     transition: all .3s ease;
   }
 
+  &.next {
+    @include triangleBottomRight(16px, $grey);
+  }
+
   &.doing {
     @include triangleBottomRight(16px, $blue);
   }

--- a/build/scss/_sections.scss
+++ b/build/scss/_sections.scss
@@ -12,6 +12,13 @@ section {
     }
   }
 
+  &#next {
+    h2 {
+      border-bottom: 3px solid $grey;
+      border-top: 3px solid $grey;
+    }
+  }
+
   &#doing {
     h2 {
       border-bottom: 3px solid $blue;

--- a/build/scss/app.scss
+++ b/build/scss/app.scss
@@ -4,6 +4,7 @@ $blue: #007bff;
 $orange: #ffc107;
 $red: #dc3545;
 $green: #28a745;
+$grey: #bbbbbb;
 
 @import "sections";
 @import "card";

--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -213,10 +213,10 @@ class Application {
         }
       }
 
-      if ($card) {
-        this.updateCard($card, card, posInColumn);
-      } else {
+      if ($card.length === 0) {
         this.dealCard(card, posInColumn);
+      } else {
+        this.updateCard($card, card, posInColumn);
       }
     }
 
@@ -304,8 +304,9 @@ class Application {
 
   private updateCard($card: JQuery<HTMLElement>, card: ICard, pos: number) {
     const correctState = $card.parents(`#${card.status}`).length > 0;
+    const correctPos = $card.prevAll(`.card`).length === pos;
 
-    if (!correctState) {
+    if (!correctState || !correctPos) {
       setTimeout(() => {
         $card.remove();
       }, 500);

--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -95,9 +95,10 @@ class Application {
     this.filterResetTimeout = 0;
   }
 
-  public dealCard(card: ICard) {
+  public dealCard(card: ICard, pos: number) {
     const tmpl: HTMLElement | null =
-      document.getElementById(card.status === 'done' ? 'thin-card-template' : 'card-template');
+      document.getElementById(card.status === 'done' || card.status === 'next' ?
+        'thin-card-template' : 'card-template');
     const parsed = document.createElement('div');
 
     if (tmpl === null) {
@@ -113,8 +114,13 @@ class Application {
 
     this.updateCardData($card, card);
 
-    $(`#${card.status}`)
-      .append(parsed.innerHTML);
+    const cardInPos = $(`#${card.status} div.card:eq(${pos})`);
+    if (cardInPos.length === 0) {
+      $(`#${card.status}`)
+        .append(parsed.innerHTML);
+    } else {
+      cardInPos.before(parsed.innerHTML);
+    }
 
     this
       .gracefulIn($(`#${card.status} #${card.id}`));
@@ -197,10 +203,20 @@ class Application {
     for (const card of cards) {
       const $card = $(`#${card.id}`);
 
+      let posInColumn = 0;
+      for (const c of cards) {
+        if (c.id === card.id) {
+          break;
+        }
+        if (c.status === card.status) {
+          posInColumn++;
+        }
+      }
+
       if ($card) {
-        this.updateCard($card, card);
+        this.updateCard($card, card, posInColumn);
       } else {
-        this.dealCard(card);
+        this.dealCard(card, posInColumn);
       }
     }
 
@@ -261,8 +277,8 @@ class Application {
               sticker.Title :
               `<img src="${sticker.Image}" alt="${sticker.Title}" title="${sticker.Title}" />`;
 
-        if (sticker.Content != "") {
-          stickerContent = stickerContent + ` <small>${sticker.Content}</small>`
+        if (sticker.Content !== '') {
+          stickerContent = `${stickerContent} <small>${sticker.Content}</small>`;
         }
 
         if (!sticker.Label) {
@@ -286,7 +302,7 @@ class Application {
     return this;
   }
 
-  private updateCard($card: JQuery<HTMLElement>, card: ICard) {
+  private updateCard($card: JQuery<HTMLElement>, card: ICard, pos: number) {
     const correctState = $card.parents(`#${card.status}`).length > 0;
 
     if (!correctState) {
@@ -295,7 +311,7 @@ class Application {
       }, 500);
 
       this.gracefulOut($card);
-      this.dealCard(card);
+      this.dealCard(card, pos);
     } else {
       this.updateCardData($card, card);
     }

--- a/build/views/index.html
+++ b/build/views/index.html
@@ -113,14 +113,10 @@
   </footer>
 
   <script id="card-template" type="text/template">
-    {{if len .Cards}}
-      {{template "card" (index .Cards 0)}}
-    {{end}}
+    {{template "card" .SampleCard }}
   </script>
   <script id="thin-card-template" type="text/template">
-    {{if len .Cards}}
-      {{template "thin-card" (index .Cards 0)}}
-    {{end}}
+    {{template "thin-card" .SampleCard }}
   </script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" crossorigin="anonymous"></script>

--- a/build/views/index.html
+++ b/build/views/index.html
@@ -41,11 +41,11 @@
   </header>
 
   <main class="row">
-    <section id="next" class="column collapsed left" style="display:none;">
+    <section id="next" class="col" data-cards="{{(len $next)}}">
       <h2>Next</h2>
 
       {{range $next}}
-        {{template "card" .}}
+        {{template "thin-card" .}}
       {{end}}
     </section>
 

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 			ApprovalLimit: 5,
 		}).
 		WithCards(combineCards(cards, doneCards), false).
+		WithSampleCard(&rubbernecker.Card{}).
 		WithTeamMembers(members).
 		WithFreeTeamMembers().
 		WithSupport(support)

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Main", func() {
 			year, month, day = time.Now().Date()
 			past             = time.Date(year, month, day, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -5).UnixNano() / int64(time.Millisecond)
 
-			apiURL          = `https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&filter=state:started,finished,delivered,rejected`
+			apiURL          = `https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&filter=state:unstarted,started,finished,delivered,rejected`
 			apiURLAccepted  = fmt.Sprintf(`https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&accepted_after=%d`, past)
 			apiURLMembers   = `https://www.pivotaltracker.com/services/v5/projects/123456/memberships`
 			apiURLSupport   = `https://api.pagerduty.com/oncalls`

--- a/pkg/pivotal/internal.go
+++ b/pkg/pivotal/internal.go
@@ -100,7 +100,7 @@ func composeState(status rubbernecker.Status) string {
 
 	switch status {
 	case rubbernecker.StatusScheduled:
-		state = pt.StoryStatePlanned
+		state = pt.StoryStateUnstarted
 	case rubbernecker.StatusDoing:
 		state = pt.StoryStateStarted
 	case rubbernecker.StatusReviewal:
@@ -113,6 +113,7 @@ func composeState(status rubbernecker.Status) string {
 		state = pt.StoryStateAccepted
 	default:
 		state = strings.Join([]string{
+			pt.StoryStateUnstarted,
 			pt.StoryStateStarted,
 			pt.StoryStateFinished,
 			pt.StoryStateDelivered,
@@ -135,7 +136,7 @@ func convertState(state string) string {
 		return rubbernecker.StatusDone.String()
 	case pt.StoryStateRejected:
 		return rubbernecker.StatusRejected.String()
-	case pt.StoryStatePlanned:
+	case pt.StoryStateUnstarted:
 		return rubbernecker.StatusScheduled.String()
 	default:
 		return "unknown"

--- a/pkg/pivotal/internal_test.go
+++ b/pkg/pivotal/internal_test.go
@@ -76,8 +76,8 @@ var _ = Describe("Pivotal internal functionality", func() {
 		reje := composeState(rubbernecker.StatusRejected)
 		done := composeState(rubbernecker.StatusDone)
 
-		Expect(all).To(Equal("started,finished,delivered,rejected"))
-		Expect(todo).To(Equal(pivotal.StoryStatePlanned))
+		Expect(all).To(Equal("unstarted,started,finished,delivered,rejected"))
+		Expect(todo).To(Equal(pivotal.StoryStateUnstarted))
 		Expect(play).To(Equal(pivotal.StoryStateStarted))
 		Expect(revi).To(Equal(pivotal.StoryStateFinished))
 		Expect(appr).To(Equal(pivotal.StoryStateDelivered))
@@ -86,7 +86,7 @@ var _ = Describe("Pivotal internal functionality", func() {
 	})
 
 	It("should convertState() correctly", func() {
-		Expect(convertState(pivotal.StoryStatePlanned)).To(Equal("next"))
+		Expect(convertState(pivotal.StoryStateUnstarted)).To(Equal("next"))
 		Expect(convertState(pivotal.StoryStateStarted)).To(Equal("doing"))
 		Expect(convertState(pivotal.StoryStateFinished)).To(Equal("reviewing"))
 		Expect(convertState(pivotal.StoryStateDelivered)).To(Equal("approving"))

--- a/pkg/rubbernecker/card.go
+++ b/pkg/rubbernecker/card.go
@@ -8,7 +8,7 @@ const (
 	// ProjectManagementService.Fetch call.
 	StatusAll Status = iota
 	// StatusScheduled should only filter the stories that are not in the
-	// StatusStarted state, but prioritised into backlock.
+	// StatusStarted state, but prioritised into backlog.
 	StatusScheduled
 	// StatusDoing should only filter the stories that are in play.
 	StatusDoing

--- a/pkg/rubbernecker/response.go
+++ b/pkg/rubbernecker/response.go
@@ -10,6 +10,7 @@ import (
 type Response struct {
 	Card            *Card       `json:"card,omitempty"`
 	Cards           Cards       `json:"cards,omitempty"`
+	SampleCard      *Card       `json:"sample_card,omitempty"`
 	Config          *Config     `json:"config,omitempty"`
 	Error           string      `json:"error,omitempty"`
 	Message         string      `json:"message,omitempty"`
@@ -41,6 +42,12 @@ func (r *Response) Template(code int, w http.ResponseWriter, templateFile ...str
 	}
 
 	return t.Execute(w, r)
+}
+
+// WithSampleCard will set a sample card used for template generation
+func (r *Response) WithSampleCard(card *Card) *Response {
+	r.SampleCard = card
+	return r
 }
 
 // WithCards will set a collection/single card for the current response.


### PR DESCRIPTION
## What

Add Next column to show backlog stories. I decided not to limit the number of stories in the column.

Also fixes live updates to put stories in correct position after status change.

## How to review

You can generate a Pivotal Tracker token on your account page.

1. Run it locally

    ```/sh
    #!/bin/bash
    
    export PIVOTAL_TRACKER_PROJECT_ID=1275640
    export PIVOTAL_TRACKER_API_TOKEN=xxx
    
    make build
    ./bin/rubbernecker
    ```
1. Change a story's status from unstarted to started and vice versa. Check if the js refresh (every 20 seconds) works correctly.
1. Change the story ordering in the backlog and check whether the change is reflected at the next auto-refresh.

## Who can review it

Not me.