### PR TITLE
Show correct number of visible cards when filtering

### DIFF
--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -330,7 +330,7 @@ class Application {
     const $sections = $('[data-cards]');
 
     $.each($sections, (_: number, section: HTMLElement) => {
-      const count = $(section).find('div.card').length;
+      const count = $(section).find('div.card:visible').length;
       const limit = parseInt($(section).find('h2 > small').attr('data-limit') || '0', 10);
 
       $(section).find('h2 > small').removeClass('text-danger');

--- a/build/views/index.html
+++ b/build/views/index.html
@@ -91,7 +91,7 @@
     </div>
 
     <section id="done" class="col" data-cards="{{(len $done)}}">
-      <h2>Done <small>{{len $done}}</small></h2>
+      <h2>Done <small><span>{{len $done}}</span></small></h2>
 
       {{range $done}}
         {{template "thin-card" .}}


### PR DESCRIPTION
# What
When filtering for tech/non-tech/all, the number of cards meeting that filter is shown at the top of a column. This commit makes that number match the number that are visible.

# How to review
1. Code review
2. Spin up rubbernecker and play with the filters. Check the numbers match.

# Who can review
Anyone