### PR TITLE
Mirrors release-stories-as-dividers behaviour from Pivotal

### DIFF
--- a/build/scss/_card.scss
+++ b/build/scss/_card.scss
@@ -23,7 +23,7 @@ $spacing: 16px;
     transition: all .3s ease;
   }
 
-  &.next {
+  &.next:not(.type-release) {
     @include triangleBottomRight(16px, $grey);
   }
 
@@ -49,6 +49,11 @@ $spacing: 16px;
     footer {
       display: none;
     }
+  }
+
+
+  &.type-release {
+    border: none;
   }
 
   &.thin {

--- a/build/ts/app.ts
+++ b/build/ts/app.ts
@@ -6,6 +6,7 @@ interface ICard {
   readonly stickers: ReadonlyArray<ISticker>;
   readonly title: string;
   readonly url: string;
+  readonly story_type: string;
 }
 
 interface IMembers {
@@ -172,8 +173,8 @@ class Application {
   }
 
   public filterNonTech(showNonTech: boolean) {
-    const nonTechCards = $('.card:has(.sticker-non-tech)');
-    const otherCards = $('.card:not(:has(.sticker-non-tech))');
+    const nonTechCards = $('.card:not(.type-release):has(.sticker-non-tech)');
+    const otherCards = $('.card:not(.type-release):not(:has(.sticker-non-tech))');
 
     if (showNonTech) {
       this.gracefulIn(nonTechCards);
@@ -297,7 +298,7 @@ class Application {
 
   private setupCard($card: JQuery<HTMLElement>, card: ICard) {
     $card
-      .attr('class', `card ${card.status}`)
+      .attr('class', `card ${card.status} type-${card.story_type}`)
       .attr('id', card.id);
 
     return this;

--- a/build/views/card.html
+++ b/build/views/card.html
@@ -1,5 +1,5 @@
 {{define "card"}}
-<div id="{{.ID}}" class="card {{.Status}}">
+<div id="{{.ID}}" class="card {{.Status}} type-{{.StoryType}}">
   <h3>
     <a href="{{.URL}}" target="_blank">{{.Title}}</a>
   </h3>

--- a/build/views/thin-card.html
+++ b/build/views/thin-card.html
@@ -1,18 +1,36 @@
 {{define "thin-card"}}
-<div id="{{.ID}}" class="card thin {{.Status}}">
-  <h3>
-    <a href="{{.URL}}" target="_blank">{{.Title}}</a>
-  </h3>
 
-  <footer>
-    <div class="labels"></div>
-    <div class="stickers">
-      {{range .Stickers}}
-        {{if not .Label}}
-          {{template "sticker" .}}
-        {{end}}
-      {{end}}
+  {{- /*
+    In Pivotal tracker, 'release' type stories are used to create separators within the backlog and icebox.
+    We mirror that in Rubbernecker so that they don't appear as visual clutter.
+  */ -}}
+  {{ if eq .StoryType "release"}}
+    <div id="{{.ID}}" class="card thin type-{{.StoryType}}">
+      <h2>{{.Title}}</h2>
     </div>
-  </footer>
-</div>
+  {{ else -}}
+    <div id="{{.ID}}" class="card thin {{.Status}} type-{{.StoryType}}">
+      <h3>
+        <a href="{{.URL}}" target="_blank">{{.Title}}</a>
+      </h3>
+
+      <footer>
+        <div class="labels">
+          <small>{{.Elapsed}} day{{if ne .Elapsed 1}}s{{end}}</small>
+          {{range .Stickers}}
+            {{if .Label}}
+              {{template "sticker" .}}
+            {{end}}
+          {{end}}
+        </div>
+        <div class="stickers">
+          {{range .Stickers}}
+            {{if not .Label}}
+              {{template "sticker" .}}
+            {{end}}
+          {{end}}
+        </div>
+      </footer>
+    </div>
+ {{- end}}
 {{end}}

--- a/main_test.go
+++ b/main_test.go
@@ -26,11 +26,11 @@ var _ = Describe("Main", func() {
 			year, month, day = time.Now().Date()
 			past             = time.Date(year, month, day, 0, 0, 0, 0, time.UTC).AddDate(0, 0, -5).UnixNano() / int64(time.Millisecond)
 
-			apiURL          = `https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&filter=state:unstarted,started,finished,delivered,rejected`
-			apiURLAccepted  = fmt.Sprintf(`https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&accepted_after=%d`, past)
+			apiURL          = `https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at,story_type&filter=state:unstarted,started,finished,delivered,rejected`
+			apiURLAccepted  = fmt.Sprintf(`https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at,story_type&accepted_after=%d`, past)
 			apiURLMembers   = `https://www.pivotaltracker.com/services/v5/projects/123456/memberships`
 			apiURLSupport   = `https://api.pagerduty.com/oncalls`
-			response        = `[{"blockers": [{"name":1234}],"transitions": [],"name": "Test Rubbernecker","current_state": "started","url": "http://localhost/story/show/561","owner_ids":[1234],"labels":[]}]`
+			response        = `[{"blockers": [{"name":1234}],"transitions": [],"name": "Test Rubbernecker","current_state": "started","url": "http://localhost/story/show/561","owner_ids":[1234],"labels":[], "story_type": "feature"}]`
 			responseMembers = `[{"person":{"id":1234,"name":"Tester"}}]`
 		)
 		fmt.Println(fmt.Sprintf(`https://www.pivotaltracker.com/services/v5/projects/123456/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&accepted_after=%d`, past))

--- a/pkg/pivotal/internal.go
+++ b/pkg/pivotal/internal.go
@@ -30,6 +30,7 @@ type story struct {
 	Blockers    []blocker    `json:"blockers,omitempty"`
 	Transitions []transition `json:"transitions,omitempty"`
 	CreatedAt   *time.Time   `json:"created_at,omitempty"`
+	StoryType   string 			 `json:"story_type"`
 }
 
 type blocker struct {

--- a/pkg/pivotal/story.go
+++ b/pkg/pivotal/story.go
@@ -37,7 +37,7 @@ func (t *Tracker) AcceptStickers(stickers rubbernecker.Stickers) {
 // FetchCards will fetch the stories from PivotalTracker.
 func (t *Tracker) FetchCards(status rubbernecker.Status, params map[string]string) error {
 	p := []string{
-		"fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at",
+		"fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at,story_type",
 	}
 
 	for key, value := range params {
@@ -106,6 +106,7 @@ func (t *Tracker) FlattenStories() (rubbernecker.Cards, error) {
 			Stickers:  stickers,
 			Title:     s.Name,
 			URL:       s.URL,
+			StoryType: s.StoryType,
 		})
 	}
 

--- a/pkg/pivotal/story_test.go
+++ b/pkg/pivotal/story_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Pivotal Stories", func() {
 		var (
 			pt rubbernecker.ProjectManagementService
 
-			apiURL   = `https://www.pivotaltracker.com/services/v5/projects/123/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at&filter=state:started`
+			apiURL   = `https://www.pivotaltracker.com/services/v5/projects/123/stories?fields=owner_ids,blockers,transitions,current_state,labels,name,url,created_at,story_type&filter=state:started`
 			response = `[{"blockers": [{"name":1234}],"transitions": [],"name": "Test Rubbernecker","current_state": "started","url": "http://localhost/story/show/561","owner_ids":[1234],"labels":[{"name":"test"}]}]`
 		)
 

--- a/pkg/rubbernecker/card.go
+++ b/pkg/rubbernecker/card.go
@@ -34,6 +34,7 @@ type Card struct {
 	Stickers  Stickers `json:"stickers"`
 	Title     string   `json:"title"`
 	URL       string   `json:"url"`
+	StoryType string   `json:"story_type"`
 }
 
 // Cards will be a rubbernecker representative of all cards.


### PR DESCRIPTION
# What
In Pivotal Tracker, release type stories are used to visually create dividers
in the backlog and icebox. In Rubbernecker, though, they appeared as regular
stories that would never move from the 'Next' column. This commit
differentiates release stories visually, to reduce the visual clutter.

# How to review
1) Code review
2) Run Rubbernecker locally and play about with it. Check the cards don't disappear when the data is updated, that filters don't affect them etc etc.

# Who can review
Anyone