### PR TITLE
Visually indicate applied filter

### DIFF
--- a/build/views/index.html
+++ b/build/views/index.html
@@ -87,30 +87,22 @@
 
 
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
-          <a class="govuk-button govuk-button--secondary" href="?">
-            Clear filters
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?include-sticker=blocked">
-            Blocked
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?include-sticker=scheduled">
-            Scheduled
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?include-sticker=comments-to-resolve">
-            Comments to resolve
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?include-sticker='small' task">
-            Small tasks
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?include-sticker=pairing">
-            Pairing
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?include-sticker=non-tech">
-            Non-Tech
-          </a>
-          <a class="govuk-button govuk-button--secondary" href="?exclude-sticker=non-tech">
-            Tech
-          </a>
+          {{ range .Filters}}
+            {{ $appliedClass := "govuk-button--secondary"}}
+            {{ if .Exclude}}
+              {{if .IsApplied $.AppliedExcludeFilters }}
+                {{$appliedClass = ""}}
+              {{end }}
+            {{ else }}
+              {{if .IsApplied $.AppliedIncludeFilters }}
+                {{$appliedClass = ""}}
+              {{end }}
+            {{end}}
+
+            <a class="govuk-button {{$appliedClass}}" href="{{.Href}}">
+              {{.FilterText}}
+            </a>
+          {{end}}
         </div>
       </header>
 

--- a/pkg/rubbernecker/filter.go
+++ b/pkg/rubbernecker/filter.go
@@ -1,0 +1,32 @@
+package rubbernecker
+
+import "fmt"
+
+type Filter struct {
+	StickerName string
+	FilterText string
+	Exclude bool
+}
+
+func (f *Filter) IsApplied(applied []string) bool {
+	for _, sticker := range applied {
+		if sticker == f.StickerName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f *Filter) Href() string {
+	if f.StickerName == "" {
+		return "?"
+	}
+
+	key := "include-sticker"
+	if f.Exclude {
+		key = "exclude-sticker"
+	}
+
+	return fmt.Sprintf("?%s=%s", key, f.StickerName)
+}

--- a/pkg/rubbernecker/response.go
+++ b/pkg/rubbernecker/response.go
@@ -10,15 +10,18 @@ import (
 
 // Response will be a standard outcome returned when hitting rubbernecker app.
 type Response struct {
-	Card            *Card       `json:"card,omitempty"`
-	Cards           Cards       `json:"cards,omitempty"`
-	SampleCard      *Card       `json:"sample_card,omitempty"`
-	Config          *Config     `json:"config,omitempty"`
-	Error           string      `json:"error,omitempty"`
-	Message         string      `json:"message,omitempty"`
-	SupportRota     SupportRota `json:"support,omitempty"`
-	TeamMembers     Members     `json:"team_members,omitempty"`
-	FreeTeamMembers Members     `json:"free_team_members,omitempty"`
+	Card                  *Card       `json:"card,omitempty"`
+	Cards                 Cards       `json:"cards,omitempty"`
+	SampleCard            *Card       `json:"sample_card,omitempty"`
+	Config                *Config     `json:"config,omitempty"`
+	Error                 string      `json:"error,omitempty"`
+	Message               string      `json:"message,omitempty"`
+	SupportRota           SupportRota `json:"support,omitempty"`
+	TeamMembers           Members     `json:"team_members,omitempty"`
+	FreeTeamMembers       Members     `json:"free_team_members,omitempty"`
+	Filters               []Filter    `json:"filters,omitempty"`
+	AppliedIncludeFilters []string    `json:"applied_include_filters,omitempty"`
+	AppliedExcludeFilters []string    `json:"applied_exclude_filters,omitempty"`
 }
 
 // JSON function will execute the response to our HTTP writer.
@@ -125,5 +128,16 @@ func (r *Response) WithFreeTeamMembers() *Response {
 		r.FreeTeamMembers = free
 	}
 
+	return r
+}
+
+func (r *Response) WithFilters(filters []Filter) *Response {
+	r.Filters = filters
+	return r
+}
+
+func (r *Response) WithAppliedFilters(include []string, exclude []string) *Response {
+	r.AppliedIncludeFilters = include
+	r.AppliedExcludeFilters = exclude
 	return r
 }


### PR DESCRIPTION
What
---
I spent a couple of minutes wondering why Rubbernecker was broken, before realising I had a filter applied. Then I realised there was no visual indication of which (if any) filter was applied. So I fixed it.

In order to be able to know which filter was applied, a type for the filters had to be introduced. The applied include and exclude filters were also recorded on the response, so that they could be used in the template.

The template now excludes the `govuk-button--secondary` class from the filters buttons IFF the filter is applied. Otherwise, the class is added.

How to review
---
1. Code review
2. Spin it up locally, apply each of the filters in turn and clear the filters. Check they're visually indicated each time

Who can review
---
Anyone