### PR TITLE
Switch escalations from PaaS team to RE

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func formatSupportNames(s rubbernecker.SupportRota) rubbernecker.SupportRota {
 	return rubbernecker.SupportRota{
 		"in-hours":     s.Get("PaaS team rota - in hours"),
 		"out-of-hours": s.Get("PaaS team rota - out of hours"),
-		"escalations":  s.Get("PaaS team Escalations - out of hours"),
+		"escalations":  s.Get("TechOps RE Incident Escalation"),
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Main", func() {
 			resp := `{"oncalls":[
 				{"user":{"summary":"X"},"schedule":{"summary":"PaaS team rota - out of hours"}},
 				{"user":{"summary":"Y"},"schedule":{"summary":"PaaS team rota - in hours"}},
-				{"user":{"summary":"Z"},"schedule":{"summary":"PaaS team Escalations - out of hours"}}
+				{"user":{"summary":"Z"},"schedule":{"summary":"TechOps RE Incident Escalation"}}
 			]}`
 			httpmock.RegisterResponder("GET", apiURLSupport, httpmock.NewStringResponder(200, resp))
 
@@ -136,7 +136,7 @@ var _ = Describe("Main", func() {
 					Member: "Y",
 				},
 				"escalations": {
-					Type:   "PaaS team Escalations - out of hours",
+					Type:   "TechOps RE Incident Escalation",
 					Member: "Z",
 				},
 			})))
@@ -165,7 +165,7 @@ var _ = Describe("Main", func() {
 			}`
 			resp3 := `{
 				"oncalls":[
-					{"user":{"summary":"Z"},"schedule":{"summary":"PaaS team Escalations - out of hours"}}
+					{"user":{"summary":"Z"},"schedule":{"summary":"TechOps RE Incident Escalation"}}
 				],
 				"limit": 1,
 				"offset": 6,
@@ -192,7 +192,7 @@ var _ = Describe("Main", func() {
 					Member: "Y",
 				},
 				"escalations": {
-					Type:   "PaaS team Escalations - out of hours",
+					Type:   "TechOps RE Incident Escalation",
 					Member: "Z",
 				},
 			})))
@@ -201,7 +201,7 @@ var _ = Describe("Main", func() {
 		It("should handle when there isn't anyone on call for a certain schedule", func() {
 			resp := `{"oncalls":[
 				{"user":{"summary":"X"},"schedule":{"summary":"PaaS team rota - out of hours"}},
-				{"user":{"summary":"Z"},"schedule":{"summary":"PaaS team Escalations - out of hours"}}
+				{"user":{"summary":"Z"},"schedule":{"summary":"TechOps RE Incident Escalation"}}
 			]}`
 			httpmock.RegisterResponder("GET", apiURLSupport, httpmock.NewStringResponder(200, resp))
 
@@ -218,7 +218,7 @@ var _ = Describe("Main", func() {
 					Member: "-",
 				},
 				"escalations": {
-					Type:   "PaaS team Escalations - out of hours",
+					Type:   "TechOps RE Incident Escalation",
 					Member: "Z",
 				},
 			})))


### PR DESCRIPTION
The PaaS team rota was long out of date. We've agreed that we're going
to switch to using the TechOps wide rota, so rubbernecker needs updating
to reflect this.

I *think* this is enough to update the thing...