### PR TITLE
Use html/template instead of text/template

### DIFF
--- a/pkg/rubbernecker/response.go
+++ b/pkg/rubbernecker/response.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"net/http"
 	"strings"
-	"text/template"
 )
 
 // Response will be a standard outcome returned when hitting rubbernecker app.

--- a/pkg/rubbernecker/response_test.go
+++ b/pkg/rubbernecker/response_test.go
@@ -174,4 +174,30 @@ var _ = Describe("Response", func() {
 		Expect(rr.Code).To(Equal(500))
 		Expect(rr.Body.String()).To(ContainSubstring("Rubbernecker could not render template"))
 	})
+
+	It("should escape HTML in templates", func() {
+
+		req, err := http.NewRequest("GET", "/", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp.WithCards(rubbernecker.Cards{
+				&rubbernecker.Card{
+					Title: "<script>alert(1)</script>",
+				},
+			}, false).Template(200, w, "./test/cards.html")
+		})
+		handler.ServeHTTP(rr, req)
+
+		Expect(rr.Code).To(Equal(200))
+
+		Expect(rr.Body.String()).NotTo(
+			ContainSubstring("<script>alert(1)</script>"),
+		)
+
+		Expect(rr.Body.String()).To(
+			ContainSubstring("&lt;script&gt;alert(1)&lt;/script&gt;"),
+		)
+	})
 })

--- a/pkg/rubbernecker/test/cards.html
+++ b/pkg/rubbernecker/test/cards.html
@@ -2,4 +2,5 @@
 {{ range .Assignees }}
 {{ printf "%s" .Name }}
 {{ end }}
+{{ .Title }}
 {{ end }}


### PR DESCRIPTION
So html in pivotal data is escaped