### PR TITLE
Obtain comms lead for support bar

### DIFF
--- a/build/views/index.html
+++ b/build/views/index.html
@@ -69,12 +69,20 @@
             <p class="govuk-body">
               <strong>In hours</strong>:
               {{(index .SupportRota "in-hours").Member}}
+              <small class="govuk-body-s" style="display: block;">
+                <strong>Comms</strong>:
+                {{(index .SupportRota "in-hours-comms").Member}}
+              </small>
             </p>
           </div>
           <div class="govuk-grid-column-one-third">
             <p class="govuk-body">
               <strong>Out of hours</strong>:
               {{(index .SupportRota "out-of-hours").Member}}
+              <small class="govuk-body-s" style="display: block;">
+                <strong>Comms</strong>:
+                {{(index .SupportRota "out-of-hours-comms").Member}}
+              </small>
             </p>
           </div>
           <div class="govuk-grid-column-one-third">

--- a/main.go
+++ b/main.go
@@ -168,9 +168,11 @@ func fetchUsers(pt *pivotal.Tracker) error {
 
 func formatSupportNames(s rubbernecker.SupportRota) rubbernecker.SupportRota {
 	return rubbernecker.SupportRota{
-		"in-hours":     s.Get("PaaS team rota - in hours"),
-		"out-of-hours": s.Get("PaaS team rota - out of hours"),
-		"escalations":  s.Get("TechOps RE Incident Escalation"),
+		"in-hours":           s.Get("PaaS team rota - in hours"),
+		"in-hours-comms":     s.Get("PaaS team rota - comms lead (in Hours)"),
+		"out-of-hours":       s.Get("PaaS team rota - out of hours"),
+		"out-of-hours-comms": s.Get("PaaS team rota - comms lead (OOH)"),
+		"escalations":        s.Get("TechOps RE Incident Escalation"),
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -127,9 +127,17 @@ var _ = Describe("Main", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(support).To(Equal(rubbernecker.SupportRota(map[string]*rubbernecker.Support{
+				"in-hours-comms": {
+					Type:   "PaaS team rota - comms lead (in Hours)",
+					Member: "-",
+				},
 				"out-of-hours": {
 					Type:   "PaaS team rota - out of hours",
 					Member: "X",
+				},
+				"out-of-hours-comms": {
+					Type:   "PaaS team rota - comms lead (OOH)",
+					Member: "-",
 				},
 				"in-hours": {
 					Type:   "PaaS team rota - in hours",
@@ -183,9 +191,17 @@ var _ = Describe("Main", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(support).To(Equal(rubbernecker.SupportRota(map[string]*rubbernecker.Support{
+				"in-hours-comms": {
+					Type:   "PaaS team rota - comms lead (in Hours)",
+					Member: "-",
+				},
 				"out-of-hours": {
 					Type:   "PaaS team rota - out of hours",
 					Member: "X",
+				},
+				"out-of-hours-comms": {
+					Type:   "PaaS team rota - comms lead (OOH)",
+					Member: "-",
 				},
 				"in-hours": {
 					Type:   "PaaS team rota - in hours",
@@ -209,9 +225,17 @@ var _ = Describe("Main", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(support).To(Equal(rubbernecker.SupportRota(map[string]*rubbernecker.Support{
+				"in-hours-comms": {
+					Type:   "PaaS team rota - comms lead (in Hours)",
+					Member: "-",
+				},
 				"out-of-hours": {
 					Type:   "PaaS team rota - out of hours",
 					Member: "X",
+				},
+				"out-of-hours-comms": {
+					Type:   "PaaS team rota - comms lead (OOH)",
+					Member: "-",
 				},
 				"in-hours": {
 					Type:   "PaaS team rota - in hours",


### PR DESCRIPTION
We'd like to expose to ourselves, the person who happens to be a comms
lead in particular situation.

We have a separate rota in our PagerDuty account and can extract a name
from there displaying in rubbernecker.