### PR TITLE
Update Pagerduty rota to use `GaaP SCS Escalation`

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func formatSupportNames(s rubbernecker.SupportRota) rubbernecker.SupportRota {
 		"in-hours-comms":     s.Get("PaaS team rota - comms lead (in Hours)"),
 		"out-of-hours":       s.Get("PaaS team rota - out of hours"),
 		"out-of-hours-comms": s.Get("PaaS team rota - comms lead (OOH)"),
-		"escalations":        s.Get("TechOps RE Incident Escalation"),
+		"escalations":        s.Get("GaaP SCS Escalation"),
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Main", func() {
 			resp := `{"oncalls":[
 				{"user":{"summary":"X"},"schedule":{"summary":"PaaS team rota - out of hours"}},
 				{"user":{"summary":"Y"},"schedule":{"summary":"PaaS team rota - in hours"}},
-				{"user":{"summary":"Z"},"schedule":{"summary":"TechOps RE Incident Escalation"}}
+				{"user":{"summary":"Z"},"schedule":{"summary":"GaaP SCS Escalation"}}
 			]}`
 			httpmock.RegisterResponder("GET", apiURLSupport, httpmock.NewStringResponder(200, resp))
 
@@ -172,7 +172,7 @@ var _ = Describe("Main", func() {
 			}`
 			resp3 := `{
 				"oncalls":[
-					{"user":{"summary":"Z"},"schedule":{"summary":"TechOps RE Incident Escalation"}}
+					{"user":{"summary":"Z"},"schedule":{"summary":"GaaP SCS Escalation"}}
 				],
 				"limit": 1,
 				"offset": 6,
@@ -207,7 +207,7 @@ var _ = Describe("Main", func() {
 					Member: "Y",
 				},
 				"escalations": {
-					Type:   "TechOps RE Incident Escalation",
+					Type:   "GaaP SCS Escalation",
 					Member: "Z",
 				},
 			})))
@@ -216,7 +216,7 @@ var _ = Describe("Main", func() {
 		It("should handle when there isn't anyone on call for a certain schedule", func() {
 			resp := `{"oncalls":[
 				{"user":{"summary":"X"},"schedule":{"summary":"PaaS team rota - out of hours"}},
-				{"user":{"summary":"Z"},"schedule":{"summary":"TechOps RE Incident Escalation"}}
+				{"user":{"summary":"Z"},"schedule":{"summary":"GaaP SCS Escalation}}
 			]}`
 			httpmock.RegisterResponder("GET", apiURLSupport, httpmock.NewStringResponder(200, resp))
 
@@ -241,7 +241,7 @@ var _ = Describe("Main", func() {
 					Member: "-",
 				},
 				"escalations": {
-					Type:   "TechOps RE Incident Escalation",
+					Type:   "GaaP SCS Escalation",
 					Member: "Z",
 				},
 			})))


### PR DESCRIPTION
We are no longer using the `TechOps Escalation` rota. This update to the new `GaaP SCS Escalation` rota that we are using