### PR TITLE
Reintroduce team split into filters

### DIFF
--- a/build/views/card.html
+++ b/build/views/card.html
@@ -22,6 +22,15 @@
             {{- else -}}
               <p class="govuk-body"><mark>NEW</mark></p>
             {{- end -}}
+            <ul class="govuk-list">
+              {{range .Stickers}}
+                {{if .Label}}
+                  <li class="{{.Class}}">
+                    {{.Title}}
+                  </li>
+                {{end}}
+              {{end}}
+            </ul>
           </div>
         </div>
 

--- a/build/views/index.html
+++ b/build/views/index.html
@@ -110,6 +110,17 @@
             Clear filters
           </a>
 
+          {{- range .Squads}}
+            {{ $buttonClass := "govuk-button--secondary" }}
+            {{- if .IsApplied $.AppliedFilterQueries }}
+              {{ $buttonClass = "" }}
+            {{- end }}
+
+            <a class="govuk-button {{$buttonClass}}" href="?{{safeURL .QueryText}}">
+              {{.DisplayText}}
+            </a>
+          {{- end }}
+
           {{- range .Filters}}
             {{ $buttonClass := "govuk-button--secondary" }}
             {{- if .IsApplied $.AppliedFilterQueries }}

--- a/dist/css/application.css
+++ b/dist/css/application.css
@@ -29,6 +29,20 @@
   text-decoration: none;
 }
 
+.card .labels ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.card .labels ul li {
+  border: 2px solid #000;
+  display: inline-block;
+  margin-right: 5px;
+  padding: 5px;
+  text-transform: uppercase;
+}
+
 .stickers {
   display: flex;
   flex-direction: row-reverse;
@@ -48,7 +62,8 @@
 }
 
 mark {
+  border: 2px solid #000;
   background-color: black;
   color: ghostwhite;
-  padding: 0.15em;
+  padding: 5px;
 }

--- a/main.go
+++ b/main.go
@@ -200,6 +200,11 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	filteredCards := cards.FilterBy(filterQueries)
 	filteredDoneCards := doneCards.FilterBy(filterQueries)
 
+	squads := []rubbernecker.Squad{
+		{DisplayText: "PaaS Squad", QueryText: "filter=squad:paas"},
+		{DisplayText: "Disco Squad", QueryText: "filter=squad:disco"},
+	}
+
 	resp.
 		WithConfig(&rubbernecker.Config{
 			ReviewalLimit: 4,
@@ -212,6 +217,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 		WithFilters(rubbernecker.DefaultFilterSet()).
 		WithAppliedFilterQueries(filterQueries).
 		WithTextFilters(filterQueries).
+		WithSquads(squads).
 		WithSupport(support)
 
 	if strings.Contains(r.Header.Get("Accept"), "json") {

--- a/pkg/rubbernecker/card.go
+++ b/pkg/rubbernecker/card.go
@@ -129,6 +129,14 @@ func (c Cards) FilterBy(filters []string) Cards {
 					shouldAdd = true
 				}
 			}
+		} else if strings.HasPrefix(filter, "squad:") {
+			squad := strings.ToLower(strings.Replace(filter, "squad:", "", -1))
+
+			for _, sticker := range card.Stickers {
+				if strings.HasPrefix(sticker.Name, "squad") && sticker.Value == squad {
+					shouldAdd = true
+				}
+			}
 		} else if strings.HasPrefix(filter, "not-sticker:") {
 			sname := strings.ToLower(strings.Replace(filter, "not-sticker:", "", -1))
 			shouldAdd = true

--- a/pkg/rubbernecker/response.go
+++ b/pkg/rubbernecker/response.go
@@ -22,6 +22,7 @@ type Response struct {
 	TeamMembers          Members     `json:"team_members,omitempty"`
 	FreeTeamMembers      Members     `json:"free_team_members,omitempty"`
 	Filters              []Filter    `json:"filers,omitempty"`
+	Squads               []Squad     `json:"squad,omitempty"`
 	AppliedFilterQueries []string    `json:"applied_filters,omitempty"`
 	TextFilters          string      `json:"text_filters,omitempty"`
 }
@@ -141,9 +142,15 @@ func (r *Response) WithFreeTeamMembers() *Response {
 	return r
 }
 
-// WithFilters will set te filters param for the current response
+// WithFilters will set the filters param for the current response
 func (r *Response) WithFilters(filters []Filter) *Response {
 	r.Filters = filters
+	return r
+}
+
+// WithSquads will set the teams param for the current response
+func (r *Response) WithSquads(squads []Squad) *Response {
+	r.Squads = squads
 	return r
 }
 

--- a/pkg/rubbernecker/squad.go
+++ b/pkg/rubbernecker/squad.go
@@ -1,0 +1,17 @@
+package rubbernecker
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Squad struct {
+	QueryText   string
+	DisplayText string
+}
+
+func (s *Squad) IsApplied(queries []string) bool {
+	fmt.Println("queries", queries)
+	fmt.Println("s.QueryText", strings.Replace(s.QueryText, "filter=", "", -1))
+	return isApplied(queries, strings.Replace(s.QueryText, "filter=", "", -1))
+}

--- a/pkg/rubbernecker/sticker.go
+++ b/pkg/rubbernecker/sticker.go
@@ -13,6 +13,7 @@ type Sticker struct {
 	Aliases  []string
 	Class    string
 	Priority int
+	Value    string
 }
 
 // Matches will check if the sticker matches the query provided by the extension.
@@ -25,6 +26,7 @@ func (s Sticker) Matches(query string) (Sticker, bool) {
 			sticker.Image = reg.ReplaceAllString(query, sticker.Image)
 			sticker.Content = reg.ReplaceAllString(query, sticker.Content)
 			sticker.Class = reg.ReplaceAllString(query, sticker.Class)
+			sticker.Value = reg.ReplaceAllString(query, sticker.Value)
 			return sticker, true
 		}
 	}

--- a/stickers.yml
+++ b/stickers.yml
@@ -34,6 +34,13 @@
   image: '/img/pear_please.svg'
   title: 'Please pair on this'
 
+- name: squad
+  label: true
+  regex: '^squad:?\s*([a-zA-Z0-9\s]+)'
+  title: '$1'
+  class: 'squad squad-$1'
+  value: '$1'
+
 - name: lead
   label: true
   regex: '^lead:?\s*([a-zA-Z0-9\s]+)'


### PR DESCRIPTION
## What

We're creating streams of work in the team... This means, we need something like squads to define different pieces of work and their alignment.

This was little bit more difficult then anticipated - I was hoping to revert 2b3cab244615764b3b0a4aa599c11fb58a5ae1f8 ...

/me shakes fist towards Amsterdam

## How to review

- `cf env rubbernecker` from production, and steal the creds
- Export stolen certs into an environment
- `go run .`
- Experience working squad filters

