### PR TITLE
Style tweaks

### DIFF
--- a/dist/css/application.css
+++ b/dist/css/application.css
@@ -173,6 +173,9 @@ h1 span {
 
 .card__heading {
   margin-bottom: 1em;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .card__heading a {
@@ -190,6 +193,7 @@ h1 span {
   border: 2px solid #000;
   display: inline-block;
   margin-right: 5px;
+  margin-bottom: .5em;
   padding: 5px;
   text-transform: uppercase;
 }


### PR DESCRIPTION
- Space card labels on smaller width
- prevent long urls in heading to from breaking out

Before

![Screenshot 2021-07-15 at 14 31 21](https://user-images.githubusercontent.com/3758555/125796453-250ae416-b1eb-486a-9c19-4b128bceab7e.png)
![Screenshot 2021-07-15 at 14 31 27](https://user-images.githubusercontent.com/3758555/125796456-5903f5bb-9cfb-4c41-a118-83aa4df957ef.png)


After

![Screenshot 2021-07-15 at 14 30 03](https://user-images.githubusercontent.com/3758555/125796313-3f12f435-a974-4dcd-a022-24626ed4da21.png)
![Screenshot 2021-07-15 at 14 30 07](https://user-images.githubusercontent.com/3758555/125796315-c08fd45d-682d-4c1c-902c-838fd8a58a22.png)
