### PR TITLE
Remove Autom8 rota check up

### DIFF
--- a/build/views/index.html
+++ b/build/views/index.html
@@ -78,10 +78,6 @@
                 <strong>Escalations</strong>:
                 {{(index .SupportRota "escalations").Member}}
               </p>
-              <p>
-                <strong>Our m8</strong>:
-                {{(index .SupportRota "autom8").Member}}
-              </p>
             </div>
           </div>
 

--- a/main.go
+++ b/main.go
@@ -177,7 +177,6 @@ func formatSupportNames(s rubbernecker.SupportRota) rubbernecker.SupportRota {
 		"in-hours-comms":     s.Get("PaaS team rota - comms lead (in Hours)"),
 		"out-of-hours":       s.Get("PaaS team rota - out of hours"),
 		"out-of-hours-comms": s.Get("PaaS team rota - comms lead (OOH)"),
-		"autom8":             s.Get("Techops Autom8"),
 		"escalations":        s.Get("GaaP SCS Escalation"),
 	}
 }


### PR DESCRIPTION
The GOV.UK PaaS team is no longer responsible for the shared concourse.
And although there is a blurry line in terms of observe, this rota is
not necessary and we're not actually paying attention to it during standups.