### PR TITLE
Correct the name of the escalations rota

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func formatSupportNames(s rubbernecker.SupportRota) rubbernecker.SupportRota {
 		"in-hours-comms":     s.Get("PaaS team rota - comms lead (in Hours)"),
 		"out-of-hours":       s.Get("PaaS team rota - out of hours"),
 		"out-of-hours-comms": s.Get("PaaS team rota - comms lead (OOH)"),
-		"escalations":        s.Get("GaaP SCS Escalation"),
+		"escalations":        s.Get("P&T SCS Escalation"),
 	}
 }
 


### PR DESCRIPTION
What
---
Goverment as a Platform escalations rota was recently replace by the Product & Technology escalations rota. As a result, we weren't seeing who to escalate to.

How to review
---
[Does it match the name in PagerDuty ?](https://governmentdigitalservice.pagerduty.com/schedules#PE6NQ9Z)