### PR TITLE
BAU - Enable GitHub actions for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+What
+----
+
+Describe what you have changed and why.
+
+How to review
+-------------
+
+Describe the steps required to test the changes.
+
+Who can review
+--------------
+
+Describe who can review the changes. Or more importantly, list the people
+that can't review, because they worked on it.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: github-action

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,0 +1,19 @@
+on: pull_request
+
+env:
+  GO_VERSION: "1.20"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+      - name: "Install Go ${{env.GO_VERSION}}"
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+        with:
+          go-version: "${{env.GO_VERSION}}"
+
+      - name: Tests
+        run: "make test"


### PR DESCRIPTION
Description:
- At present we rely on developers to run tests locally but this isn't ideal so enable it on PR runs
- Configure dependabot to create PRs against GitHub actions
- Add a PR request template