### PR TITLE
BAU - Upgrade to Go 1.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,6 @@
 An application that converts various tools the GOV.UK PaaS team is using into a
 friendly kanban wall used for standup and quick reference of what's going on.
 
-## Dependencies
-
-There are various dependencies for Node as well as Golang that would need to be
-installed before compilation of the code.
-
-The make file has a target for them all:
-
-```sh
-make dependencies
-```
-
 ## Building
 
 The repo comes in with a make file which makes it easier to build the project
@@ -42,6 +31,8 @@ following:
 ```sh
 ./bin/rubbernecker
 ```
+
+You should be able to view the application at [http://localhost:8080](http://localhost:8080)
 
 ### Requirements
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-rubbernecker
 
-go 1.18
+go 1.20
 
 require (
 	github.com/PagerDuty/go-pagerduty v0.0.0-20170914160704-078a3284fb0e


### PR DESCRIPTION
Description:
-------------
- Go 1.18 isn't supported in our current go-buildpack of [v1.10.10](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.10.10) so upgrade to Go 1.20
