### PR TITLE
185827364 - Add redirect app for rubbernecker

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -10,3 +10,4 @@ package-lock.json
 package.json
 tsconfig.json
 tslint.json
+redirect/

--- a/redirect/manifest.yml
+++ b/redirect/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+  - name: paas-rubbernecker-redirect
+    buildpack: nginx_buildpack
+    memory: 32M
+    instances: 2
+
+    env:
+      REDIRECT_DOMAIN: rubbernecker.cloudapps.digital

--- a/redirect/nginx.conf
+++ b/redirect/nginx.conf
@@ -1,0 +1,24 @@
+worker_processes 1;
+daemon off;
+
+error_log /dev/stderr;
+events { worker_connections 1024; }
+
+http {
+  charset utf-8;
+  log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
+  access_log /dev/stdout cloudfoundry;
+
+  keepalive_timeout 30;
+  port_in_redirect off;
+  server_tokens off;
+
+  server {
+    listen {{ port }};
+    server_name localhost;
+
+    location / {
+      return 301 https://{{ env "REDIRECT_DOMAIN" }}$request_uri;
+    }
+  }
+}


### PR DESCRIPTION
Description:
----
- As part of migrating Rubbernecker to London region this means the domain will change to [rubbernecker.london.cloudapps.digital](rubbernecker.london.cloudapps.digital)
- We wish to keep the old domain so add an nginx redirect hosted in the Ireland region
